### PR TITLE
V3.1.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,13 +5,18 @@ All notable changes to this project will be documented in this file since v2.0.0
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.3] - 2022-09-??
+## [3.1.3] - 2022-09-26
+
+### Added
+
+- Output final service parameters and mounted files after dumping a composition
 
 ### Fixed
 
 - Allow empty optional services list.
 - Allow passing empty option value via universal options like `--with-web-root=""`.
 - Make upgrade.sh more compatible with the latest Git versions.
+- Setting non-interactive mode for the `magento:setup` command.
 
 
 ## [3.1.2] - 2022-09-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file since v2.0.0
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2022-09-??
+
+### Fixed
+
+- Allow empty optional services list.
+
+
 ## [3.1.2] - 2022-09-08
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow empty optional services list.
+- Allow passing empty option value via universal options like `--with-web-root=""`.
 - Make upgrade.sh more compatible with the latest Git versions.
-
 
 
 ## [3.1.2] - 2022-09-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow empty optional services list.
+- Make upgrade.sh more compatible with the latest Git versions.
+
 
 
 ## [3.1.2] - 2022-09-08

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "defaultvalue/dockerizer_for_php",
     "description": "Docker-based development for PHP projects with transparent Docker configurations.",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "type": "project",
     "authors": [{
         "name": "Maksym Zaporozhets",

--- a/src/Console/Command/AbstractParameterAwareCommand.php
+++ b/src/Console/Command/AbstractParameterAwareCommand.php
@@ -140,7 +140,7 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
 
         // No required value in the non-interactive mode -> exception
         if (
-            !$value
+            $value === null
             && $optionDefinition->getMode() === InputOption::VALUE_REQUIRED
             && !$input->isInteractive()
         ) {
@@ -151,7 +151,7 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
 
         // No value passed in the input
         if (
-            !$value
+            $value === null
             && $optionDefinition instanceof InteractiveOptionInterface
             && $input->isInteractive()
         ) {
@@ -206,7 +206,7 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
                     return $this->getOptionValue($input, $output, $optionDefinition, --$retries);
                 }
 
-                $output->writeln("<error>Can't proceed in the non-interactive mode! Exiting...</error>");
+                throw new \InvalidArgumentException('Can\'t proceed in the non-interactive mode! Exiting...');
             }
         }
 

--- a/src/Console/Command/AbstractParameterAwareCommand.php
+++ b/src/Console/Command/AbstractParameterAwareCommand.php
@@ -173,6 +173,8 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
 
                     try {
                         $value = $questionHelper->ask($input, $output, $question);
+                        // Empty user input is ok for options like `--with-web_root`
+                        $value ??= '';
                     } catch (\Exception $e) {
                         $output->writeln("<error>{$e->getMessage()}</error>");
                         $value = null;
@@ -183,7 +185,7 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
 
         // Still no value passed for the required option
         if (
-            !$value
+            (!$value && $value !== '0') // Value like '0' is fine, though it is FALSE in PHP
             && $optionDefinition->getMode() === InputOption::VALUE_REQUIRED
             && $input->isInteractive()
         ) {
@@ -206,7 +208,9 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
                     return $this->getOptionValue($input, $output, $optionDefinition, --$retries);
                 }
 
-                throw new \InvalidArgumentException('Can\'t proceed in the non-interactive mode! Exiting...');
+                $output->writeln("<error>Can\'t proceed in the non-interactive mode! Exiting...</error>");
+
+                throw $e;
             }
         }
 

--- a/src/Console/Command/AbstractParameterAwareCommand.php
+++ b/src/Console/Command/AbstractParameterAwareCommand.php
@@ -208,7 +208,7 @@ abstract class AbstractParameterAwareCommand extends \Symfony\Component\Console\
                     return $this->getOptionValue($input, $output, $optionDefinition, --$retries);
                 }
 
-                $output->writeln("<error>Can\'t proceed in the non-interactive mode! Exiting...</error>");
+                $output->writeln('<error>Can\'t proceed in the non-interactive mode! Exiting...</error>');
 
                 throw $e;
             }

--- a/src/Console/Command/Magento/SetUp.php
+++ b/src/Console/Command/Magento/SetUp.php
@@ -192,7 +192,7 @@ class SetUp extends \DefaultValue\Dockerizer\Console\Command\AbstractParameterAw
         // to the command `composition:build-from-template`
         $command = $this->getApplication()->find($additionalOptions['command']);
 
-        if ($command->run($this->buildInput($input, $additionalOptions), $output)) {
+        if ($command->run($this->buildInput($input, $additionalOptions, $input->isInteractive()), $output)) {
             throw new \RuntimeException('Can\'t build composition for the project');
         }
     }
@@ -200,11 +200,13 @@ class SetUp extends \DefaultValue\Dockerizer\Console\Command\AbstractParameterAw
     /**
      * @param ArgvInput|ArrayInput $input
      * @param array $additionalOptions
+     * @param bool $isInteractive
      * @return ArrayInput
      */
     private function buildInput(
         ArgvInput|ArrayInput $input,
-        array $additionalOptions = []
+        array $additionalOptions = [],
+        bool $isInteractive = true
     ): ArrayInput {
         // ArgvInput|ArrayInput have `__toString` method, allowing to collect and proxy options to another command
         // Not yet tested with `ArrayInput`!
@@ -251,6 +253,9 @@ class SetUp extends \DefaultValue\Dockerizer\Console\Command\AbstractParameterAw
             return str_starts_with($a, '--with-');
         });
 
-        return new ArrayInput($inputArray);
+        $input = new ArrayInput($inputArray);
+        $input->setInteractive($isInteractive);
+
+        return $input;
     }
 }

--- a/src/Console/CommandOption/OptionDefinition/OptionalServices.php
+++ b/src/Console/CommandOption/OptionDefinition/OptionalServices.php
@@ -54,7 +54,7 @@ class OptionalServices extends \DefaultValue\Dockerizer\Console\CommandOption\Op
     public function validate(mixed $value): array
     {
         // Empty value is fine for optional services
-        if (is_null($value)) {
+        if ($value === null || $value === '') {
             return array_values($this->valueByGroup);
         }
 

--- a/src/Console/CommandOption/OptionDefinition/UniversalReusableOption.php
+++ b/src/Console/CommandOption/OptionDefinition/UniversalReusableOption.php
@@ -132,8 +132,8 @@ final class UniversalReusableOption implements
      */
     public function validate(mixed $value): mixed
     {
-        // No value, but all services have the value set as expected
-        if (!$value && !$this->composition->isParameterMissed($this->name)) {
+        // User input is empty, but at least one service has the parameter value set
+        if ($value === null && !$this->composition->isParameterMissed($this->name)) {
             return $this->composition->getParameterValue($this->name);
         }
 

--- a/src/Docker/Compose/Composition.php
+++ b/src/Docker/Compose/Composition.php
@@ -231,6 +231,19 @@ class Composition
             );
         }
 
+        $output->writeln('');
+        $output->writeln('Final service parameters list:');
+        $parameters = $this->getParameters();
+
+        foreach (array_merge($parameters['regular_options'], $parameters['universal_options']) as $parameter) {
+            $message = sprintf(
+                '- <info>%s</info>: <info>%s</info>',
+                $parameter,
+                $this->getParameterValue($parameter)
+            );
+            $output->writeln($message);
+        }
+
         // 3. Dump all mounted files
         $mountedFiles = [];
 
@@ -239,11 +252,17 @@ class Composition
             $mountedFiles[] = $service->compileMountedFiles();
         }
 
-        $mountedFiles = array_unique(array_merge(...$mountedFiles));
+        if ($mountedFiles = array_unique(array_merge(...$mountedFiles))) {
+            $output->writeln('');
+            $output->writeln('Mounted files list:');
+        }
 
         foreach ($mountedFiles as $relativeFileName => $mountedFileContent) {
             $this->filesystem->filePutContents($dockerComposeDir . $relativeFileName, $mountedFileContent);
+            $output->writeln('- ' . $relativeFileName);
         }
+
+        $output->writeln('');
 
         return $modificationContext;
     }

--- a/src/Docker/Compose/Composition/Service.php
+++ b/src/Docker/Compose/Composition/Service.php
@@ -145,7 +145,7 @@ class Service extends \DefaultValue\Dockerizer\Filesystem\ProcessibleFile\Abstra
      */
     public function setParameterValue(string $parameter, mixed $value): void
     {
-        if (is_null($value)) {
+        if ($value === null) {
             // This should not happen, but need to test
             throw new \InvalidArgumentException("Value for $parameter must not be empty");
         }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -84,7 +84,7 @@ done
 cd ${PROJECTS_ROOT_DIR}docker_infrastructure/
 git config core.fileMode false
 git reset --hard HEAD
-git pull origin master
+git pull origin master --no-rebase
 # Refresh all images if outdated, pull if not yet present
 docker pull traefik:v2.2
 docker pull mysql:5.6
@@ -110,7 +110,7 @@ cd ${PROJECTS_ROOT_DIR}dockerizer_for_php/
 git config core.fileMode false
 git reset --hard HEAD
 git checkout master
-git pull origin master
+git pull origin master --no-rebase
 composer install
 
 echo "TRAEFIK_SSL_CONFIGURATION_FILE=${PROJECTS_ROOT_DIR}docker_infrastructure/local_infrastructure/configuration/certificates.toml" > ${PROJECTS_ROOT_DIR}dockerizer_for_php/.env.local
@@ -121,7 +121,7 @@ if test -d "${PROJECTS_ROOT_DIR}magento-coding-standard"; then
     git config core.fileMode false
     git reset --hard HEAD
     git checkout master
-    git pull origin master
+    git pull origin master --no-rebase
     composer install
     npm install
 fi


### PR DESCRIPTION
### Added

- Output final service parameters and mounted files after dumping a composition

### Fixed

- Allow empty optional services list.
- Allow passing empty option value via universal options like `--with-web-root=""`.
- Make upgrade.sh more compatible with the latest Git versions.
- Setting non-interactive mode for the `magento:setup` command.