### PR TITLE
ext-curl was added to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "readme": "https://github.com/DefaultValue/dockerizer_for_php/blob/master/Readme.md",
     "require": {
         "php": "~8.0.2|~8.1|~8.2",
+        "ext-curl": "*",
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
Good day @maksymz 

I discovered that Dockerizer is not working correctly without the curl extension in the system, so I added it to the composer.json.
![image](https://github.com/DefaultValue/dockerizer_for_php/assets/57250120/997f8c21-ec8f-475a-a454-a5ad3a00e337)


Regards,
Serhii.