### PR TITLE
v3.5.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - Unreleased
+
+### Added
+
+- Magento 2.4.8+ `Nginx + Varnish + Nginx + PHP-FPM` web stack.
+- `php_fpm_development_image` dev-tools service for the FPM stack.
+- `php_apache_development_image_8_3` dev-tools service — variant of
+  `php_apache_development_image` that tracks the new PHP 8.3+ image tag scheme.
+
+### Changed
+
+- Docker image tagging policy for PHP 8.3+: tags now include the web server
+  variant — `{version}-{apache|fpm}-{production|development}` (e.g.
+  `defaultvalue/php:8.4.19-apache-production`,
+  `defaultvalue/php:8.4.19-fpm-development`). PHP ≤ 8.2 images keep the previous
+  `{version}-{stage}` scheme.
+- Apache service templates `dv_php_apache_8_3.yaml` and
+  `dv_php_apache_unsecure_8_3.yaml` reference
+  `{{image_version}}-apache-production`.
+- Compositions using PHP 8.3+ Apache services (Magento 2.4.7, 2.4.8, 2.4.9)
+  reference `php_apache_development_image_8_3`.
+
 ## [3.4.2] - 2026-04-08
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ and this project adheres to
 
 ### Changed
 
+- UX: show recommended templates between the choice list and the input prompt.
 - Docker image tagging policy for PHP 8.3+: tags now include the web server
   variant — `{version}-{apache|fpm}-{production|development}` (e.g.
   `defaultvalue/php:8.4.19-apache-production`,

--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,13 @@ and this project adheres to
 - Compositions using PHP 8.3+ Apache services (Magento 2.4.7, 2.4.8, 2.4.9)
   reference `php_apache_development_image_8_3`.
 
+### Fixed
+
+- Generated composition `Readme.md` now shows the `/console` path for the Apache
+  ActiveMQ Artemis dashboard URL.
+- RabbitMQ service template (`dv_rabbitmq.yaml`) volume mount target corrected
+  from `/var/lib/mysql` to `/var/lib/rabbitmq`.
+
 ## [3.4.2] - 2026-04-08
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.5.0] - Unreleased
+## [3.5.0] - 2026-05-13
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "defaultvalue/dockerizer_for_php",
     "description": "Docker-based development for PHP projects with transparent Docker configurations.",
-    "version": "3.4.2",
+    "version": "3.5.0",
     "type": "project",
     "authors": [{
         "name": "Maksym Zaporozhets",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			path: src/Console/Command/Magento/TestTemplates.php
 
 		-
-			message: '#^Method DefaultValue\\Dockerizer\\Console\\Command\\Magento\\TestTemplates\:\:npmInstallAndRunGrunt\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: src/Console/Command/Magento/TestTemplates.php
-
-		-
 			message: '#^Call to function is_array\(\) with array\{list\<string\>\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/src/Console/Command/Composition/AbstractTestCommand.php
+++ b/src/Console/Command/Composition/AbstractTestCommand.php
@@ -73,9 +73,13 @@ abstract class AbstractTestCommand extends \Symfony\Component\Console\Command\Co
     protected function testResponseIs200ok(string $testUrl, string $errorMessage, int $retries = 120): void
     {
         $initialRetriesCount = $retries;
+        $lastStatus = null;
+        $lastError = null;
         // Starting containers and running healthcheck may take quite long, especially in the multithread test
 
         while ($retries) {
+            $attempt = $initialRetriesCount - $retries + 1;
+
             try {
                 $request = $this->httpClient->request(
                     'GET',
@@ -83,10 +87,17 @@ abstract class AbstractTestCommand extends \Symfony\Component\Console\Command\Co
                     [
                         'verify_peer' => false,
                         'verify_host' => false,
+                        // Bound each attempt: `timeout` = idle (no bytes) gap, `max_duration` = total wall clock.
+                        // Without these, a stalled TCP/TLS handshake can block a single retry for ~60s
+                        // (php.ini `default_socket_timeout`) and silently burn through the whole retry budget.
+                        'timeout' => 5,
+                        'max_duration' => 10,
                     ]
                 );
+                $lastStatus = $request->getStatusCode();
+                $lastError = null;
 
-                if ($request->getStatusCode() === 200) {
+                if ($lastStatus === 200) {
                     $this->logger->notice("$retries of $initialRetriesCount retries left to fetch $testUrl");
 
                     return;
@@ -94,9 +105,22 @@ abstract class AbstractTestCommand extends \Symfony\Component\Console\Command\Co
             } catch (TransportExceptionInterface $e) {
                 // Retry on transport errors (timeouts, connection refused, etc.)
                 // This is expected during container startup and after composition restarts
+                $lastStatus = null;
+                $lastError = $e->getMessage();
+
                 if ($retries === 1) {
                     throw $e;
                 }
+            }
+
+            if ($attempt % 10 === 0) {
+                $this->logger->notice(sprintf(
+                    'Retry %d/%d for %s: %s',
+                    $attempt,
+                    $initialRetriesCount,
+                    $testUrl,
+                    $lastStatus !== null ? "status=$lastStatus" : "transport error: $lastError"
+                ));
             }
 
             --$retries;

--- a/src/Console/Command/Composition/BuildFromTemplate.php
+++ b/src/Console/Command/Composition/BuildFromTemplate.php
@@ -130,6 +130,10 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
             CommandOptionDomains::OPTION_NAME
         ]);
 
+        // Track resolved option values so we can render a reproducible command into the Readme.
+        // Interactive prompts don't write values back onto $input, so we capture at resolution time.
+        $resolvedOptions = [];
+
         // @TODO: Filesystem\Firewall to check current directory and protect from misuse!
         // Maybe ask for confirmation in such case, but still allow running inside the allowed directory(ies)
         $templateCode = $this->getCommandSpecificOptionValue(
@@ -137,6 +141,7 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
             $output,
             CommandOptionCompositionTemplate::OPTION_NAME
         );
+        $resolvedOptions[CommandOptionCompositionTemplate::OPTION_NAME] = (string) $templateCode;
         $template = $this->templateCollection->getByCode($templateCode);
 
         if (!$template instanceof \DefaultValue\Dockerizer\Docker\Compose\Composition\Template) {
@@ -148,8 +153,9 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
         // === Stage 1: Get all services we want to add to the composition ===
         // For now, services can't depend on other services. Thus, you need to create a service template that consists
         // of multiple services if necessary.
-        $addServices = function ($optionName) use ($input, $output) {
+        $addServices = function ($optionName) use ($input, $output, &$resolvedOptions) {
             $services = $this->getCommandSpecificOptionValue($input, $output, $optionName);
+            $resolvedOptions[$optionName] = is_array($services) ? implode(',', $services) : (string) $services;
 
             foreach ($services as $serviceName) {
                 $this->composition->addService($serviceName);
@@ -167,10 +173,9 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
                 continue;
             }
 
-            $this->composition->setServiceParameter(
-                $optionName,
-                $this->getCommandSpecificOptionValue($input, $output, $optionName)
-            );
+            $value = $this->getCommandSpecificOptionValue($input, $output, $optionName);
+            $resolvedOptions[$optionName] = is_array($value) ? implode(' ', $value) : (string) $value;
+            $this->composition->setServiceParameter($optionName, $value);
         }
 
         // Must unset variable, because missed parameters list has changed after asking for required options
@@ -198,11 +203,14 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
         // Ask only for missed parameters
         foreach ($this->composition->getParameters()['universal_options'] as $universalOptionName) {
             // Option is supposed to be missed if neither template nor
-            $this->composition->setServiceParameter(
-                $universalOptionName,
-                $this->getUniversalReusableOptionValue($input, $output, $universalOptionName)
-            );
+            $value = $this->getUniversalReusableOptionValue($input, $output, $universalOptionName);
+            $resolvedOptions[UniversalReusableOption::NAME_PREFIX . $universalOptionName] = (string) $value;
+            $this->composition->setServiceParameter($universalOptionName, $value);
         }
+
+        $consoleCommand = $this->buildReproducibleCommand($resolvedOptions, false);
+        $readmeCommand = $this->buildReproducibleCommand($resolvedOptions, true);
+        $this->composition->setReproducibleCommand($readmeCommand);
 
         // === Stage 4: Dump composition ===
         // @TODO: add --dry-run option to list all files and their content
@@ -210,16 +218,77 @@ class BuildFromTemplate extends \DefaultValue\Dockerizer\Console\Command\Abstrac
             $this->composition->dump(
                 $output,
                 $projectRoot,
-                $this->getCommandSpecificOptionValue($input, $output, CommandOptionForce::OPTION_NAME)
+                $this->getCommandSpecificOptionValue($input, $output, CommandOptionForce::OPTION_NAME),
             );
         }
 
-        // Dump the whole command to copy-paste and reuse it will all parameters
-        // @TODO: `php ~/misc/apps/dockerizer_for_php_3/bin/dockerizer com:bui` - returns just 'com:bui' :(
-        $output->writeln((string) $input);
+        $output->writeln('<info>Composition build command with all parameters:</info>');
+        $output->writeln($consoleCommand);
 
         // @TODO: connect service with infrastructure if needed - add TraefikAdapter
         return self::SUCCESS;
+    }
+
+    /**
+     * Option-name patterns that likely carry secrets. The Readme version of the reproducible command
+     * replaces these values with `[redacted]` so users can safely commit `.dockerizer/` to a repo
+     * without leaking credentials. Pattern is a case-insensitive substring match on the option name
+     * (with the `with-` prefix already stripped to a bare parameter name).
+     */
+    private const SENSITIVE_OPTION_NAME_PATTERNS = [
+        'password',
+        'secret',
+        'token',
+        'user', // matches user, username, mysql_user, artemis_username, rabbitmq_username, etc.
+    ];
+
+    /**
+     * Render a copy-pasteable shell command that regenerates this composition.
+     * Excludes orchestration flags (`--no-dump`, `--force`, `--no-interaction`, `--path`)
+     * — the user wants a clean rebuild command, not the internal invocation.
+     *
+     * @param array<string, string> $resolvedOptions
+     * @param bool $redactSensitive When true, replace values of secret-looking options with `[redacted]`.
+     *     Use for the Readme copy (may be committed to a repo); keep false for the console echo.
+     * @return string
+     */
+    private function buildReproducibleCommand(array $resolvedOptions, bool $redactSensitive): string
+    {
+        $tokens = [];
+
+        foreach ($resolvedOptions as $name => $value) {
+            if ($value === '') {
+                continue;
+            }
+
+            $emittedValue = ($redactSensitive && $this->isSensitiveOptionName($name)) ? '[redacted]' : $value;
+            $tokens[] = '--' . $name . '=' . escapeshellarg($emittedValue);
+        }
+
+        $scriptPath = $_SERVER['PHP_SELF'] ?? 'bin/dockerizer';
+        $continuation = ' \\' . PHP_EOL . '    ';
+
+        return 'php ' . $scriptPath . ' ' . $this->getName() . $continuation . implode($continuation, $tokens);
+    }
+
+    /**
+     * @param string $optionName Full option name as it appears on the CLI, e.g. `with-mysql_user`.
+     * @return bool
+     */
+    private function isSensitiveOptionName(string $optionName): bool
+    {
+        $bareName = str_starts_with($optionName, UniversalReusableOption::NAME_PREFIX)
+            ? substr($optionName, strlen(UniversalReusableOption::NAME_PREFIX))
+            : $optionName;
+        $bareName = strtolower($bareName);
+
+        foreach (self::SENSITIVE_OPTION_NAME_PATTERNS as $pattern) {
+            if (str_contains($bareName, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Console/CommandOption/OptionDefinition/CompositionTemplate.php
+++ b/src/Console/CommandOption/OptionDefinition/CompositionTemplate.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace DefaultValue\Dockerizer\Console\CommandOption\OptionDefinition;
 
 use DefaultValue\Dockerizer\Console\CommandOption\ValidationException as OptionValidationException;
+use DefaultValue\Dockerizer\Console\Question\ChoiceQuestionWithRecommendation;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
@@ -82,12 +83,13 @@ class CompositionTemplate implements
      */
     public function getQuestion(): ChoiceQuestion
     {
-        $questionText = $this->getTemplateRecommendation();
-
-        return new ChoiceQuestion(
-            $questionText . PHP_EOL . '<info>Select composition template to use:</info> ',
+        $question = new ChoiceQuestionWithRecommendation(
+            'Select composition template to use',
             $this->templateCollection->getCodes()
         );
+        $question->setPostChoicesMessage($this->getTemplateRecommendation());
+
+        return $question;
     }
 
     /**
@@ -175,23 +177,42 @@ class CompositionTemplate implements
 
         $suitableTemplates = array_diff_key($suitableTemplates, $recommendedTemplates);
 
+        $indexByCode = array_flip($this->templateCollection->getCodes());
+        $indexWidth = max(1, strlen((string) (count($indexByCode) - 1)));
+        $formatIndex = static fn (string $code): string => isset($indexByCode[$code])
+            ? '[' . str_pad((string) $indexByCode[$code], $indexWidth) . ']'
+            : '[?]';
+
         if ($suitableTemplates) {
             $templateRecommendations .= 'Potentially suitable templates are:' . PHP_EOL;
 
             foreach ($suitableTemplates as $templateCode => $packages) {
-                $templateRecommendations .= sprintf('- %s (%s)', $templateCode, implode(', ', $packages)) . PHP_EOL;
+                $templateRecommendations .= sprintf(
+                    '- %s %s (%s)',
+                    $formatIndex($templateCode),
+                    $templateCode,
+                    implode(', ', $packages)
+                ) . PHP_EOL;
             }
         }
 
         if ($recommendedTemplates) {
-            $templateRecommendations .= PHP_EOL . 'Recommended templates are:' . PHP_EOL;
+            if ($templateRecommendations !== '') {
+                $templateRecommendations .= PHP_EOL;
+            }
+
+            $templateRecommendations .= PHP_EOL . '<info>Recommended templates are:</info>' . PHP_EOL;
             $templateRecommendations .= implode(PHP_EOL, array_map(
-                static fn ($templateCode) => '- ' . $templateCode,
+                static fn (string $templateCode): string => sprintf(
+                    '- %s %s',
+                    $formatIndex($templateCode),
+                    $templateCode
+                ),
                 array_keys($recommendedTemplates)
             ));
         }
 
-        return $templateRecommendations . PHP_EOL;
+        return $templateRecommendations;
     }
 
     /**

--- a/src/Console/Helper/QuestionHelper.php
+++ b/src/Console/Helper/QuestionHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) Default Value LLC.
+ * This source file is subject to the License https://github.com/DefaultValue/dockerizer_for_php/LICENSE.txt
+ * Do not change this file if you want to upgrade the tool to the newer versions in the future
+ * Please, contact us at https://default-value.com/#contact if you wish to customize this tool
+ * according to you business needs
+ */
+
+declare(strict_types=1);
+
+namespace DefaultValue\Dockerizer\Console\Helper;
+
+use DefaultValue\Dockerizer\Console\Question\ChoiceQuestionWithRecommendation;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Extends Symfony's question helper to render a post-choices message between the choices list and the ` > ` prompt.
+ * Only activates for {@see ChoiceQuestionWithRecommendation}; every other question falls through to the parent.
+ */
+class QuestionHelper extends SymfonyQuestionHelper
+{
+    protected function writePrompt(OutputInterface $output, Question $question): void
+    {
+        if (!$question instanceof ChoiceQuestionWithRecommendation || $question->getPostChoicesMessage() === '') {
+            parent::writePrompt($output, $question);
+
+            return;
+        }
+
+        $text = OutputFormatter::escapeTrailingBackslash($question->getQuestion());
+        $default = $question->getDefault();
+        $choices = $question->getChoices();
+
+        if ($default === null) {
+            $header = sprintf(' <info>%s</info>:', $text);
+        } else {
+            $defaultString = (string) $default;
+
+            if ($question->isMultiselect()) {
+                $labels = [];
+
+                foreach (explode(',', $defaultString) as $value) {
+                    $key = trim($value);
+                    $labels[] = (string) ($choices[$key] ?? $key);
+                }
+
+                $header = sprintf(
+                    ' <info>%s</info> [<comment>%s</comment>]:',
+                    $text,
+                    OutputFormatter::escape(implode(', ', $labels))
+                );
+            } else {
+                $label = (string) ($choices[$defaultString] ?? $defaultString);
+                $header = sprintf(
+                    ' <info>%s</info> [<comment>%s</comment>]:',
+                    $text,
+                    OutputFormatter::escape($label)
+                );
+            }
+        }
+
+        $output->writeln($header);
+        $output->writeln($this->formatChoiceQuestionChoices($question, 'comment'));
+        $output->writeln($question->getPostChoicesMessage());
+        $output->write($question->getPrompt());
+    }
+}

--- a/src/Console/Question/ChoiceQuestionWithRecommendation.php
+++ b/src/Console/Question/ChoiceQuestionWithRecommendation.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) Default Value LLC.
+ * This source file is subject to the License https://github.com/DefaultValue/dockerizer_for_php/LICENSE.txt
+ * Do not change this file if you want to upgrade the tool to the newer versions in the future
+ * Please, contact us at https://default-value.com/#contact if you wish to customize this tool
+ * according to you business needs
+ */
+
+declare(strict_types=1);
+
+namespace DefaultValue\Dockerizer\Console\Question;
+
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+/**
+ * ChoiceQuestion that carries an extra message rendered between the list of choices and the input prompt.
+ * Long lists push the question text off-screen, so hints/recommendations belong directly above the prompt.
+ */
+class ChoiceQuestionWithRecommendation extends ChoiceQuestion
+{
+    private string $postChoicesMessage = '';
+
+    public function getPostChoicesMessage(): string
+    {
+        return $this->postChoicesMessage;
+    }
+
+    public function setPostChoicesMessage(string $message): self
+    {
+        $this->postChoicesMessage = $message;
+
+        return $this;
+    }
+}

--- a/src/Docker/Compose/Composition.php
+++ b/src/Docker/Compose/Composition.php
@@ -49,6 +49,8 @@ class Composition
 
     private Template $template;
 
+    private ?string $reproducibleCommand = null;
+
     /**
      * @param \DefaultValue\Dockerizer\Docker\Compose $dockerCompose
      * @param \DefaultValue\Dockerizer\Filesystem\Filesystem $filesystem
@@ -208,6 +210,18 @@ class Composition
     }
 
     /**
+     * Store a shell command that reproduces this composition so it can be written into the generated Readme.
+     * Secrets (passwords, usernames, tokens) should already be redacted by the caller.
+     *
+     * @param string|null $reproducibleCommand
+     * @return void
+     */
+    public function setReproducibleCommand(?string $reproducibleCommand): void
+    {
+        $this->reproducibleCommand = $reproducibleCommand;
+    }
+
+    /**
      * @TODO: Maybe should move this to some external service. Will leave here for now because YAGNI
      *
      * @param OutputInterface $output
@@ -241,12 +255,12 @@ class Composition
         }
 
         $output->writeln('');
-        $output->writeln('Final service parameters list:');
+        $output->writeln('<info>Final service parameters list:</info>');
         $parameters = $this->getParameters();
 
         foreach (array_merge($parameters['regular_options'], $parameters['universal_options']) as $parameter) {
             $message = sprintf(
-                '- <info>%s</info>: <info>%s</info>',
+                '- %s: <info>%s</info>',
                 $parameter,
                 $this->getParameterValue($parameter)
             );
@@ -424,6 +438,7 @@ class Composition
         return $modificationContext->setDockerComposeDir($dockerComposeDir)
             ->setProjectRoot($projectRoot)
             ->setCompositionYaml($yamlContent)
-            ->setDevToolsYaml($devToolsYaml);
+            ->setDevToolsYaml($devToolsYaml)
+            ->setReproducibleCommand($this->reproducibleCommand);
     }
 }

--- a/src/Docker/Compose/Composition/PostCompilation/ModificationContext.php
+++ b/src/Docker/Compose/Composition/PostCompilation/ModificationContext.php
@@ -26,6 +26,8 @@ class ModificationContext implements DataTransferObjectInterface
 
     private array $readme = [];
 
+    private ?string $reproducibleCommand = null;
+
     /**
      * @return string
      */
@@ -121,13 +123,46 @@ class ModificationContext implements DataTransferObjectInterface
     }
 
     /**
+     * Append a Readme section at the given index. Indexes are expected to be unique per composition build
+     * — by convention modifiers pass their `getSortOrder()`, which the ModifierCollection already
+     * enforces as unique. Duplicate indexes throw instead of silently overwriting a prior section.
+     *
      * @param int $index
      * @param string $readmeMd
      * @return ModificationContext
      */
     public function appendReadme(int $index, string $readmeMd): ModificationContext
     {
+        if (isset($this->readme[$index])) {
+            throw new \DomainException(sprintf(
+                'Readme index %d is already taken. Pick a unique sort-order value for each modifier.',
+                $index
+            ));
+        }
+
         $this->readme[$index] = $readmeMd;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReproducibleCommand(): ?string
+    {
+        return $this->reproducibleCommand;
+    }
+
+    /**
+     * Shell command (with redacted secrets) that rebuilds this composition. Consumed by the
+     * ReproducibleCommand modifier to append the rebuild section to the Readme.
+     *
+     * @param string|null $reproducibleCommand
+     * @return ModificationContext
+     */
+    public function setReproducibleCommand(?string $reproducibleCommand): ModificationContext
+    {
+        $this->reproducibleCommand = $reproducibleCommand;
 
         return $this;
     }

--- a/src/Docker/Compose/Composition/PostCompilation/Modifier/Hosts.php
+++ b/src/Docker/Compose/Composition/PostCompilation/Modifier/Hosts.php
@@ -22,6 +22,16 @@ use DefaultValue\Dockerizer\Lib\ArrayHelper;
 class Hosts implements ModifierInterface
 {
     /**
+     * Map of Docker Compose service keys to the URL path where their admin UI is served.
+     * Used only when rendering the Readme's "Urls list"; /etc/hosts entries stay bare hostnames.
+     *
+     * @var array<string, string>
+     */
+    private const DASHBOARD_PATHS = [
+        'activemq-artemis' => '/console',
+    ];
+
+    /**
      * @param \DefaultValue\Dockerizer\Shell\Shell $shell
      * @param \DefaultValue\Dockerizer\Filesystem\Filesystem $filesystem
      * @param \DefaultValue\Dockerizer\Validation\Domain $domainValidator
@@ -41,6 +51,7 @@ class Hosts implements ModifierInterface
         $allDomains = [];
         $secureDomains = [];
         $insecureDomains = [];
+        $hostnameToPath = [];
         $fullYaml = ArrayHelper::arrayMergeReplaceRecursive(
             $modificationContext->getCompositionYaml(),
             $modificationContext->getDevToolsYaml(),
@@ -48,16 +59,22 @@ class Hosts implements ModifierInterface
         $hostsFile = $this->filesystem->getHostsFilePath();
 
         // Find all containers with TLS enabled
-        foreach ($fullYaml['services'] as $service) {
+        foreach ($fullYaml['services'] as $serviceName => $service) {
             if (!isset($service['labels'])) {
                 continue;
             }
+
+            $dashboardPath = self::DASHBOARD_PATHS[$serviceName] ?? '';
 
             foreach ($service['labels'] as $label) {
                 if (str_contains($label, 'http.rule=Host') || str_contains($label, 'https.rule=Host')) {
                     preg_match_all('/Host\(`([^`]+)`\)/', $label, $matches);
                     $domains = $matches[1];
                     $allDomains[] = $domains;
+
+                    foreach ($domains as $domain) {
+                        $hostnameToPath[$domain] = $dashboardPath;
+                    }
 
                     if (str_contains($label, 'http.rule=Host')) {
                         $insecureDomains[] = $domains;
@@ -83,12 +100,20 @@ class Hosts implements ModifierInterface
         }
 
         $inlineDomains = '127.0.0.1 ' . implode(' ', $allDomains);
-        $domainsAsList = array_reduce($secureDomains, static function ($carry, $domain) {
-            return $carry . "- [https://$domain](https://$domain) \n";
-        });
-        $domainsAsList .= array_reduce($insecureDomains, static function ($carry, $domain) {
-            return $carry . "- [http://$domain](http://$domain) \n";
-        });
+        $domainsAsList = array_reduce(
+            $secureDomains,
+            static function ($carry, $domain) use ($hostnameToPath) {
+                $path = $hostnameToPath[$domain] ?? '';
+                return $carry . "- [https://$domain$path](https://$domain$path) \n";
+            }
+        );
+        $domainsAsList .= array_reduce(
+            $insecureDomains,
+            static function ($carry, $domain) use ($hostnameToPath) {
+                $path = $hostnameToPath[$domain] ?? '';
+                return $carry . "- [http://$domain$path](http://$domain$path) \n";
+            }
+        );
         $domainsAsList = trim($domainsAsList);
 
         $readmeMd = <<<README

--- a/src/Docker/Compose/Composition/PostCompilation/Modifier/ReproducibleCommand.php
+++ b/src/Docker/Compose/Composition/PostCompilation/Modifier/ReproducibleCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) Default Value LLC.
+ * This source file is subject to the License https://github.com/DefaultValue/dockerizer_for_php/LICENSE.txt
+ * Do not change this file if you want to upgrade the tool to the newer versions in the future
+ * Please, contact us at https://default-value.com/#contact if you wish to customize this tool
+ * according to you business needs
+ */
+
+declare(strict_types=1);
+
+namespace DefaultValue\Dockerizer\Docker\Compose\Composition\PostCompilation\Modifier;
+
+use DefaultValue\Dockerizer\Docker\Compose\Composition\PostCompilation\ModificationContext;
+use DefaultValue\Dockerizer\Docker\Compose\Composition\PostCompilation\ModifierInterface;
+
+/**
+ * Append the shell command that rebuilds this composition to the Readme.
+ * The command is produced by `composition:build-from-template` with secrets already redacted,
+ * so the generated `.dockerizer/` directory can be committed to a repository without leaking
+ * credentials. Runs last (sort order 999) so it appears as the final Readme section.
+ */
+class ReproducibleCommand implements ModifierInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function modify(ModificationContext $modificationContext): void
+    {
+        $command = $modificationContext->getReproducibleCommand();
+
+        if ($command === null || $command === '') {
+            return;
+        }
+
+        $readmeMd = "## Rebuild this composition ##\n\n"
+            . "Use this command to regenerate the composition. "
+            . "Edit the options first if you want to recreate it with different settings. "
+            . "Secrets (passwords, usernames, tokens) are shown as `[redacted]` — "
+            . "replace them with real values before running.\n\n"
+            . "```shell\n"
+            . $command . "\n"
+            . "```";
+
+        $modificationContext->appendReadme($this->getSortOrder(), $readmeMd);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSortOrder(): int
+    {
+        return 999;
+    }
+}

--- a/src/Docker/Compose/Composition/PostCompilation/Modifier/Traefik.php
+++ b/src/Docker/Compose/Composition/PostCompilation/Modifier/Traefik.php
@@ -90,7 +90,6 @@ class Traefik extends AbstractSslAwareModifier implements
               - "80:80"
               - "443:443"
             ```
-
             MARKUP;
         // phpcs:enable
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -10,6 +10,7 @@
 
 namespace DefaultValue\Dockerizer;
 
+use DefaultValue\Dockerizer\Console\Helper\QuestionHelper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
@@ -36,6 +37,7 @@ class Kernel
 
         $application = new Application();
         $application->setCommandLoader($commandLoader);
+        $application->getHelperSet()->set(new QuestionHelper());
         // @TODO: may be needed to get exception info for parallel runs
         // $application->setCatchExceptions(false);
 

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
@@ -21,7 +21,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
@@ -21,7 +21,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
@@ -21,7 +21,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
@@ -21,7 +21,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
@@ -23,7 +23,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
@@ -39,7 +39,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
@@ -34,7 +34,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
@@ -34,7 +34,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
@@ -34,7 +34,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
@@ -36,7 +36,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p0.yaml
@@ -21,7 +21,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -29,7 +29,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p1_p2.yaml
@@ -21,7 +21,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -29,7 +29,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p3_p4.yaml
@@ -23,7 +23,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -31,7 +31,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p0.yaml
@@ -34,7 +34,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -42,7 +42,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
@@ -34,7 +34,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -42,7 +42,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
@@ -36,7 +36,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
@@ -44,7 +44,7 @@ app:
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.3.30.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Apache)
+  description: Magento 2.4.8 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.8 <2.4.8-p1'
+    magento/project-enterprise-edition: '>=2.4.8 <2.4.8-p1'
+    magento/product-community-edition: '>=2.4.8 <2.4.8-p1'
+    magento/product-enterprise-edition: '>=2.4.8 <2.4.8-p1'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -15,53 +15,65 @@ app:
     rabbitmq_username: magento
     rabbitmq_password: magento
     rabbitmq_vhost: /
-    artemis_username: magento
-    artemis_password: magento
   composition:
     required:
-      nginx:
+      nginx_ssl_proxy:
         nginx_latest:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_7:
-          service: dv_varnish_magento
+        varnish_7_6:
+          service: dv_varnish_magento_v7
           parameters:
-            backend_host: php
+            backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.7-alpine
+            varnish_version: 7.6-alpine
             varnish_port: 80
-      apache:
-        php_8_5_apache:
-          service: dv_php_apache_unsecure_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
+      nginx_web:
+        nginx_magento_for_fpm:
+          service: dv_nginx_magento_for_fpm
           parameters:
-            image_version: '8.5.4'
-            web_root: 'pub/'
-        php_8_4_apache:
-          service: dv_php_apache_unsecure_8_3
+            upstream_fpm: 'php:9000'
+      php_fpm:
+        php_8_4_fpm:
+          service: dv_php_fpm_8_3_to_8_5
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_fpm_development_image
             - mailhog
           parameters:
             image_version: '8.4.19'
             web_root: 'pub/'
+        php_8_3_fpm:
+          service: dv_php_fpm_8_3_to_8_5
+          dev_tools:
+            - php_fpm_development_image
+            - mailhog
+          parameters:
+            image_version: '8.3.30.1'
+            web_root: 'pub/'
       database:
+        mysql_8_4_persistent:
+          service: dv_mysql_8_0_to_8_4
+          dev_tools: phpmyadmin
+          parameters:
+            mysql_version: '8.4'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
-        opensearch_3_0_0:
+        elasticsearch_8_17_0_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.0'
+        opensearch_2_19_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '2.19.0'
+            opensearch_dashboards_version: '2.19.0'
 
     optional:
       cache:
@@ -73,11 +85,7 @@ app:
           service: dv_redis
           parameters:
             redis_version: '7.2'
-      message_queue:
-        activemq_artemis_2:
-          service: dv_activemq_artemis
-          parameters:
-            artemis_version: '2.53.0'
+      rabbitmq:
         rabbitmq_4_1:
           service: dv_rabbitmq
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p1_p2.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Apache)
+  description: Magento 2.4.8-p1 - 2.4.8-p2 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.8-p1 <2.4.8-p3'
+    magento/project-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
+    magento/product-community-edition: '>=2.4.8-p1 <2.4.8-p3'
+    magento/product-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -15,53 +15,65 @@ app:
     rabbitmq_username: magento
     rabbitmq_password: magento
     rabbitmq_vhost: /
-    artemis_username: magento
-    artemis_password: magento
   composition:
     required:
-      nginx:
+      nginx_ssl_proxy:
         nginx_latest:
           service: dv_nginx_proxy_for_varnish
       varnish:
         varnish_7_7:
-          service: dv_varnish_magento
+          service: dv_varnish_magento_v7
           parameters:
-            backend_host: php
+            backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
             varnish_version: 7.7-alpine
             varnish_port: 80
-      apache:
-        php_8_5_apache:
-          service: dv_php_apache_unsecure_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
+      nginx_web:
+        nginx_magento_for_fpm:
+          service: dv_nginx_magento_for_fpm
           parameters:
-            image_version: '8.5.4'
-            web_root: 'pub/'
-        php_8_4_apache:
-          service: dv_php_apache_unsecure_8_3
+            upstream_fpm: 'php:9000'
+      php_fpm:
+        php_8_4_fpm:
+          service: dv_php_fpm_8_3_to_8_5
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_fpm_development_image
             - mailhog
           parameters:
             image_version: '8.4.19'
             web_root: 'pub/'
+        php_8_3_fpm:
+          service: dv_php_fpm_8_3_to_8_5
+          dev_tools:
+            - php_fpm_development_image
+            - mailhog
+          parameters:
+            image_version: '8.3.30.1'
+            web_root: 'pub/'
       database:
+        mysql_8_4_persistent:
+          service: dv_mysql_8_0_to_8_4
+          dev_tools: phpmyadmin
+          parameters:
+            mysql_version: '8.4'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
-        opensearch_3_0_0:
+        elasticsearch_8_17_0_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.0'
+        opensearch_2_19_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '2.19.0'
+            opensearch_dashboards_version: '2.19.0'
 
     optional:
       cache:
@@ -73,11 +85,7 @@ app:
           service: dv_redis
           parameters:
             redis_version: '7.2'
-      message_queue:
-        activemq_artemis_2:
-          service: dv_activemq_artemis
-          parameters:
-            artemis_version: '2.53.0'
+      rabbitmq:
         rabbitmq_4_1:
           service: dv_rabbitmq
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Apache)
+  description: Magento 2.4.8-p3 - 2.4.8-p4 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.8-p3 <2.4.9'
+    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.9'
+    magento/product-community-edition: '>=2.4.8-p3 <2.4.9'
+    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.9'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -19,43 +19,57 @@ app:
     artemis_password: magento
   composition:
     required:
-      nginx:
+      nginx_ssl_proxy:
         nginx_latest:
           service: dv_nginx_proxy_for_varnish
       varnish:
         varnish_7_7:
-          service: dv_varnish_magento
+          service: dv_varnish_magento_v7
           parameters:
-            backend_host: php
+            backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
             varnish_version: 7.7-alpine
             varnish_port: 80
-      apache:
-        php_8_5_apache:
-          service: dv_php_apache_unsecure_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
+      nginx_web:
+        nginx_magento_for_fpm:
+          service: dv_nginx_magento_for_fpm
           parameters:
-            image_version: '8.5.4'
-            web_root: 'pub/'
-        php_8_4_apache:
-          service: dv_php_apache_unsecure_8_3
+            upstream_fpm: 'php:9000'
+      php_fpm:
+        php_8_4_fpm:
+          service: dv_php_fpm_8_3_to_8_5
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_fpm_development_image
             - mailhog
           parameters:
             image_version: '8.4.19'
             web_root: 'pub/'
+        php_8_3_fpm:
+          service: dv_php_fpm_8_3_to_8_5
+          dev_tools:
+            - php_fpm_development_image
+            - mailhog
+          parameters:
+            image_version: '8.3.30.1'
+            web_root: 'pub/'
       database:
+        mysql_8_4_persistent:
+          service: dv_mysql_8_0_to_8_4
+          dev_tools: phpmyadmin
+          parameters:
+            mysql_version: '8.4'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
+        elasticsearch_8_17_0_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.0'
         opensearch_3_0_0:
           service: opensearch
           dev_tools: opensearch_dashboards

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_beta1.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_beta1.yaml
@@ -23,7 +23,7 @@ app:
         php_8_5_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.5.4'
@@ -31,7 +31,7 @@ app:
         php_8_4_apache:
           service: dv_php_apache_8_3
           dev_tools:
-            - php_apache_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_beta1.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_beta1.yaml
@@ -1,5 +1,5 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Apache)
+  description: Magento 2.4.9-beta1 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
     magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
@@ -19,32 +19,37 @@ app:
     artemis_password: magento
   composition:
     required:
-      nginx:
+      nginx_ssl_proxy:
         nginx_latest:
           service: dv_nginx_proxy_for_varnish
       varnish:
         varnish_7_7:
-          service: dv_varnish_magento
+          service: dv_varnish_magento_v7
           parameters:
-            backend_host: php
+            backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
             varnish_version: 7.7-alpine
             varnish_port: 80
-      apache:
-        php_8_5_apache:
-          service: dv_php_apache_unsecure_8_3
+      nginx_web:
+        nginx_magento_for_fpm:
+          service: dv_nginx_magento_for_fpm
+          parameters:
+            upstream_fpm: 'php:9000'
+      php_fpm:
+        php_8_5_fpm:
+          service: dv_php_fpm_8_3_to_8_5
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_fpm_development_image
             - mailhog
           parameters:
             image_version: '8.5.4'
             web_root: 'pub/'
-        php_8_4_apache:
-          service: dv_php_apache_unsecure_8_3
+        php_8_4_fpm:
+          service: dv_php_fpm_8_3_to_8_5
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_fpm_development_image
             - mailhog
           parameters:
             image_version: '8.4.19'

--- a/templates/vendor/defaultvalue/dockerizer-templates/dev_tools/php_apache_development_image_8_3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/dev_tools/php_apache_development_image_8_3.yaml
@@ -1,0 +1,10 @@
+services:
+  php:
+    image: defaultvalue/php:{{image_version}}-apache-development
+    extra_hosts:
+      # Required for xDebug on Linux hosts till docker.host.internal is not available by default - https://github.com/docker/libnetwork/pull/2348/files
+      - 'host.docker.internal:host-gateway'
+    environment:
+      # Go is required to catch emails with Mailhog and mhsendmail (Sendmail replacement)
+      - ADDITIONAL_PATH=/usr/local/go/bin
+      - PHP_IDE_CONFIG=serverName={{domains|first}}

--- a/templates/vendor/defaultvalue/dockerizer-templates/dev_tools/php_fpm_development_image.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/dev_tools/php_fpm_development_image.yaml
@@ -1,0 +1,10 @@
+services:
+  php:
+    image: defaultvalue/php:{{image_version}}-fpm-development
+    extra_hosts:
+      # Required for xDebug on Linux hosts till docker.host.internal is not available by default - https://github.com/docker/libnetwork/pull/2348/files
+      - 'host.docker.internal:host-gateway'
+    environment:
+      # Go is required to catch emails with Mailhog and mhsendmail (Sendmail replacement)
+      - ADDITIONAL_PATH=/usr/local/go/bin
+      - PHP_IDE_CONFIG=serverName={{domains|first}}

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_magento_for_fpm.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_magento_for_fpm.yaml
@@ -1,0 +1,10 @@
+# Inner Nginx that serves Magento static assets and proxies PHP requests to PHP-FPM.
+# Reached only from the `varnish-cache` container over the Docker network.
+services:
+  nginx-magento:
+    image: nginx:latest
+    restart: always
+    volumes:
+      - .:/var/www/html
+      - ./nginx_magento_for_fpm/virtual-host.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx_magento_for_fpm/magento.nginx.conf.sample:/etc/nginx/magento/magento.nginx.conf.sample:ro

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/nginx_magento_for_fpm/magento.nginx.conf.sample
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/nginx_magento_for_fpm/magento.nginx.conf.sample
@@ -1,0 +1,251 @@
+## Example configuration:
+# upstream fastcgi_backend {
+#    # use tcp connection
+#    # server  127.0.0.1:9000;
+#    # or socket
+#    server   unix:/var/run/php/php7.4-fpm.sock;
+# }
+# server {
+#    listen 80;
+#    server_name mage.dev;
+#    set $MAGE_ROOT /var/www/magento2;
+#    set $MAGE_DEBUG_SHOW_ARGS 0;
+#    include /vagrant/magento2/nginx.conf.sample;
+# }
+#
+## Optional override of deployment mode. We recommend you use the
+## command 'bin/magento deploy:mode:set' to switch modes instead.
+##
+## set $MAGE_MODE default; # or production or developer
+##
+## If you set MAGE_MODE in server config, you must pass the variable into the
+## PHP entry point blocks, which are indicated below. You can pass
+## it in using:
+##
+## fastcgi_param  MAGE_MODE $MAGE_MODE;
+##
+## In production mode, you should uncomment the 'add_header Cache-Control "public, max-age=31536000, immutable"' directive in the /static/ location block
+
+# Modules can be loaded only at the very beginning of the Nginx config file, please move the line below to the main config file
+# load_module /etc/nginx/modules/ngx_http_image_filter_module.so;
+
+root $MAGE_ROOT/pub;
+
+index index.php;
+autoindex off;
+charset UTF-8;
+error_page 404 403 = /errors/404.php;
+#add_header "X-UA-Compatible" "IE=Edge";
+
+
+# Deny access to sensitive files
+location /.user.ini {
+    deny all;
+}
+
+# PHP entry point for setup application
+location ~* ^/setup($|/) {
+    root $MAGE_ROOT;
+    location ~ ^/setup/index.php {
+        deny all;
+        # If you want to enable the web based setup functionality, add your
+        # ip address to the allow list below or comment out the deny all above.
+        # allow 127.0.0.1;
+
+        fastcgi_pass   fastcgi_backend;
+
+        fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
+        fastcgi_read_timeout 600s;
+        fastcgi_connect_timeout 600s;
+
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        include        fastcgi_params;
+    }
+
+    location ~ ^/setup/(?!pub/). {
+        deny all;
+    }
+
+    location ~ ^/setup/pub/ {
+        add_header X-Frame-Options "SAMEORIGIN";
+    }
+}
+
+# PHP entry point for update application
+location ~* ^/update($|/) {
+    root $MAGE_ROOT;
+
+    location ~ ^/update/index.php {
+        fastcgi_split_path_info ^(/update/index.php)(/.+)$;
+        fastcgi_pass   fastcgi_backend;
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        fastcgi_param  PATH_INFO        $fastcgi_path_info;
+        include        fastcgi_params;
+    }
+
+    # Deny everything but index.php
+    location ~ ^/update/(?!pub/). {
+        deny all;
+    }
+
+    location ~ ^/update/pub/ {
+        add_header X-Frame-Options "SAMEORIGIN";
+    }
+}
+
+location / {
+    try_files $uri $uri/ /index.php$is_args$args;
+}
+
+location /pub/ {
+    location ~ ^/pub/media/(downloadable|customer|import|custom_options|theme_customization/.*\.xml) {
+        deny all;
+    }
+    alias $MAGE_ROOT/pub/;
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+location /static/ {
+    # Uncomment the following line in production mode
+    # add_header Cache-Control "public, max-age=31536000, immutable";
+
+    # Remove signature of the static files that is used to overcome the browser cache
+    location ~ ^/static/version\d*/ {
+        rewrite ^/static/version\d*/(.*)$ /static/$1 last;
+    }
+
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2|html|json|webmanifest)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header X-Frame-Options "SAMEORIGIN";
+
+        if (!-f $request_filename) {
+            rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+        }
+    }
+    location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
+        add_header Cache-Control "no-store";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires    off;
+
+        if (!-f $request_filename) {
+           rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+        }
+    }
+    if (!-f $request_filename) {
+        rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+    }
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+location /media/ {
+
+## The following section allows to offload image resizing from Magento instance to the Nginx.
+## Catalog image URL format should be set accordingly.
+## See https://experienceleague.adobe.com/docs/commerce-admin/config/general/web.html
+#   location ~* ^/media/catalog/.* {
+#
+#       # Replace placeholders and uncomment the line below to serve product images from public S3
+#       # See examples of S3 authentication at https://github.com/anomalizer/ngx_aws_auth
+#       # resolver 8.8.8.8;
+#       # proxy_pass https://<bucket-name>.<region-name>.amazonaws.com;
+#
+#       set $width "-";
+#       set $height "-";
+#       if ($arg_width != '') {
+#           set $width $arg_width;
+#       }
+#       if ($arg_height != '') {
+#           set $height $arg_height;
+#       }
+#       image_filter resize $width $height;
+#       image_filter_jpeg_quality 90;
+#   }
+
+    # try_files $uri $uri/ /get.php$is_args$args;
+
+    location ~ ^/media/theme_customization/.*\.xml {
+        deny all;
+    }
+
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2)$ {
+        add_header Cache-Control "public";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires +1y;
+        try_files $uri $uri/ /get.php$is_args$args;
+    }
+    location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
+        add_header Cache-Control "no-store";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires    off;
+        # try_files $uri $uri/ /get.php$is_args$args;
+    }
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+location /media/customer/ {
+    deny all;
+}
+
+location /media/downloadable/ {
+    deny all;
+}
+
+location /media/import/ {
+    deny all;
+}
+
+location /media/custom_options/ {
+    deny all;
+}
+
+location /errors/ {
+    location ~* \.xml$ {
+        deny all;
+    }
+}
+
+# PHP entry point for main application
+location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
+    try_files $uri =404;
+    fastcgi_pass   fastcgi_backend;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+
+    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+    fastcgi_read_timeout 600s;
+    fastcgi_connect_timeout 600s;
+
+    fastcgi_index  index.php;
+    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    include        fastcgi_params;
+}
+
+gzip on;
+gzip_disable "msie6";
+
+gzip_comp_level 6;
+gzip_min_length 1100;
+gzip_buffers 16 8k;
+gzip_proxied any;
+gzip_types
+    text/plain
+    text/css
+    text/js
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/xml+rss
+    image/svg+xml;
+gzip_vary on;
+
+# Banned locations (only reached if the earlier PHP entry point regexes don't match)
+location ~* (\.php$|\.phtml$|\.htaccess$|\.htpasswd$|\.git) {
+    deny all;
+}

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/nginx_magento_for_fpm/virtual-host.conf
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/nginx_magento_for_fpm/virtual-host.conf
@@ -1,0 +1,14 @@
+upstream fastcgi_backend {
+    server {{upstream_fpm}};
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{domains}};
+
+    set $MAGE_ROOT /var/www/html;
+    set $MAGE_MODE developer;
+
+    include /etc/nginx/magento/magento.nginx.conf.sample;
+}

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache.yaml
@@ -44,4 +44,4 @@ services:
       # Substitute default host file so that it does not interact with our custom host
       - ./apache/virtual-host.conf:/etc/apache2/sites-enabled/000-default.conf:ro
       # For testing with composer packages cache
-      - ${HOME}/misc/apps/composer_package_cache:/home/docker/.composer/cache
+      #- ${HOME}/misc/apps/composer_package_cache:/home/docker/.composer/cache

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache_8_3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache_8_3.yaml
@@ -11,7 +11,7 @@ services:
     # Must be enclosed in double quotes, otherwise YAML is invalid
     # Container name is used as a directory name to dump composition files
     container_name: '{{domains|first}}-{{environment}}'
-    image: defaultvalue/php:{{image_version}}-production
+    image: defaultvalue/php:{{image_version}}-apache-production
     user: docker:docker
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache_unsecure_8_3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_apache_unsecure_8_3.yaml
@@ -4,7 +4,7 @@ services:
     # Must be enclosed in double quotes, otherwise YAML is invalid
     # Container name is used to identify container with PHP to install application
     container_name: '{{domains|first}}-apache-{{environment}}'
-    image: defaultvalue/php:{{image_version}}-production
+    image: defaultvalue/php:{{image_version}}-apache-production
     user: docker:docker
     sysctls:
       - net.ipv4.ip_unprivileged_port_start=0

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_fpm_8_3_to_8_5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/php/dv_php_fpm_8_3_to_8_5.yaml
@@ -1,0 +1,12 @@
+# PHP-FPM container. Sits behind an inner Nginx (dv_nginx_magento_for_fpm) that
+# proxies requests over the Docker network at php:9000. No public ports.
+services:
+  php:
+    container_name: '{{domains|first}}-fpm-{{environment}}'
+    image: defaultvalue/php:{{image_version}}-fpm-production
+    user: docker:docker
+    restart: always
+    volumes:
+      - .:/var/www/html
+      - ./fpm/php-fpm-pool.conf:/usr/local/etc/php-fpm.d/zz-pool.conf:ro
+      #- ${HOME}/misc/apps/composer_package_cache:/home/docker/.composer/cache

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/php/fpm/php-fpm-pool.conf
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/php/fpm/php-fpm-pool.conf
@@ -1,0 +1,15 @@
+[www]
+; Overrides for Magento workloads. Merged on top of the image-baked zz-docker.conf.
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 10
+clear_env = no
+
+; Uncomment to surface FPM status for debugging
+; pm.status_path = /status
+; ping.path = /ping
+
+catch_workers_output = yes
+decorate_workers_output = no

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/rabbitmq/dv_rabbitmq.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/rabbitmq/dv_rabbitmq.yaml
@@ -13,7 +13,7 @@ services:
       RABBITMQ_DEFAULT_PASS: '{{rabbitmq_password}}'
       RABBITMQ_DEFAULT_VHOST: '{{rabbitmq_vhost}}'
     volumes:
-      - rabbitmq_{{environment}}_data:/var/lib/mysql
+      - rabbitmq_{{environment}}_data:/var/lib/rabbitmq
     # Health check for service dependencies
     healthcheck:
       test: "rabbitmqctl status"

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/dv_varnish_magento_v7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/dv_varnish_magento_v7.yaml
@@ -1,0 +1,7 @@
+# Varnish 7 with Magento's upstream varnish7.vcl - https://hub.docker.com/_/varnish
+services:
+  varnish-cache:
+    image: varnish:{{varnish_version}}
+    restart: always
+    volumes:
+      - ./varnish/varnish_magento_v7.vcl:/etc/varnish/default.vcl:ro

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/varnish/varnish_magento_v7.vcl
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/varnish/varnish_magento_v7.vcl
@@ -1,0 +1,258 @@
+# VCL version 5.0 is not supported so it should be 4.0 even though actually used Varnish version is 7
+vcl 4.0;
+
+import std;
+# The minimal Varnish version is 7.0
+# For SSL offloading, pass the following header in your proxy server or load balancer: '{{ssl_offloaded_header}}: https'
+
+backend default {
+    .host = "{{backend_host}}";
+    .port = "80";
+    .first_byte_timeout = 600s;
+    .probe = {
+        .url = "{{health_check}}";
+        .timeout = 2s;
+        .interval = 5s;
+        .window = 10;
+        .threshold = 5;
+    }
+}
+
+acl purge {
+    "localhost";
+    "{{backend_host}}";
+}
+
+sub vcl_recv {
+    if (req.restarts > 0) {
+        set req.hash_always_miss = true;
+    }
+
+    # Sorting query string parameters
+    if (req.url ~ "\?.+&.+") {
+        set req.url = std.querysort(req.url);
+    }
+
+    if (req.method == "PURGE") {
+        if (client.ip !~ purge) {
+            return (synth(405, "Method not allowed"));
+        }
+        # To use the X-Pool header for purging varnish during automated deployments, make sure the X-Pool header
+        # has been added to the response in your backend server config. This is used, for example, by the
+        # capistrano-magento2 gem for purging old content from varnish during it's deploy routine.
+        if (!req.http.X-Magento-Tags-Pattern && !req.http.X-Pool) {
+            return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
+        }
+        if (req.http.X-Magento-Tags-Pattern) {
+          ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+        }
+        if (req.http.X-Pool) {
+          ban("obj.http.X-Pool ~ " + req.http.X-Pool);
+        }
+        return (synth(200, "Purged"));
+    }
+
+    if (req.method != "GET" &&
+        req.method != "HEAD" &&
+        req.method != "PUT" &&
+        req.method != "POST" &&
+        req.method != "TRACE" &&
+        req.method != "OPTIONS" &&
+        req.method != "DELETE") {
+          /* Non-RFC2616 or CONNECT which is weird. */
+          return (pipe);
+    }
+
+    # We only deal with GET and HEAD by default
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    # Bypass customer, shopping cart, checkout
+    if (req.url ~ "/customer" || req.url ~ "/checkout") {
+        return (pass);
+    }
+
+    # Bypass health check requests
+    if (req.url ~ "^/(pub/)?(health_check.php)$") {
+        return (pass);
+    }
+
+    # Set initial grace period usage status
+    set req.http.grace = "none";
+
+    # normalize url in case of leading HTTP scheme and domain
+    set req.url = regsub(req.url, "^http[s]?://", "");
+
+    # collect all cookies
+    std.collect(req.http.Cookie);
+
+    # Remove all marketing get parameters to minimize the cache objects
+    if (req.url ~ "(\?|&)(gad_source|gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
+        set req.url = regsuball(req.url, "(gad_source|gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
+        set req.url = regsub(req.url, "[?|&]+$", "");
+    }
+
+    # Static files caching
+    if (req.url ~ "^/(pub/)?(media|static)/") {
+        # Static files should not be cached by default
+        return (pass);
+
+        # But if you use a few locales and don't use CDN you can enable caching static files by commenting previous line (#return (pass);) and uncommenting next 3 lines
+        #unset req.http.Https;
+        #unset req.http.{{ssl_offloaded_header}};
+        #unset req.http.Cookie;
+    }
+
+    # Bypass authenticated GraphQL requests without a X-Magento-Cache-Id
+    if (req.url ~ "/graphql" && !req.http.X-Magento-Cache-Id && req.http.Authorization ~ "^Bearer") {
+        return (pass);
+    }
+
+    return (hash);
+}
+
+sub vcl_hash {
+    if ((req.url !~ "/graphql" || !req.http.X-Magento-Cache-Id) && req.http.cookie ~ "X-Magento-Vary=") {
+        hash_data(regsub(req.http.cookie, "^.*?X-Magento-Vary=([^;]+);*.*$", "\1"));
+    }
+
+    # To make sure http users don't see ssl warning
+    if (req.http.{{ssl_offloaded_header}}) {
+        hash_data(req.http.{{ssl_offloaded_header}});
+    }
+    /* { { design_exceptions_code } } */
+
+    if (req.url ~ "/graphql") {
+        call process_graphql_headers;
+    }
+}
+
+sub process_graphql_headers {
+    if (req.http.X-Magento-Cache-Id) {
+        hash_data(req.http.X-Magento-Cache-Id);
+
+        # When the frontend stops sending the auth token, make sure users stop getting results cached for logged-in users
+        if (req.http.Authorization ~ "^Bearer") {
+            hash_data("Authorized");
+        }
+    }
+
+    if (req.http.Store) {
+        hash_data(req.http.Store);
+    }
+
+    if (req.http.Content-Currency) {
+        hash_data(req.http.Content-Currency);
+    }
+}
+
+sub vcl_backend_response {
+
+    set beresp.grace = 3d;
+
+    if (beresp.http.content-type ~ "text") {
+        set beresp.do_esi = true;
+    }
+
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+        set beresp.do_gzip = true;
+    }
+
+    if (beresp.http.X-Magento-Debug) {
+        set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
+    }
+
+    # cache only successfully responses and 404s that are not marked as private
+    if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 86400s;
+        return (deliver);
+    }
+
+    # validate if we need to cache it and prevent from setting cookie
+    if (beresp.ttl > 0s && (bereq.method == "GET" || bereq.method == "HEAD")) {
+        # Collapse beresp.http.set-cookie in order to merge multiple set-cookie headers
+        # Although it is not recommended to collapse set-cookie header,
+        # it is safe to do it here as the set-cookie header is removed below
+        std.collect(beresp.http.set-cookie);
+        # Do not cache the response under current cache key (hash),
+        # if the response has X-Magento-Vary but the request does not.
+        if ((bereq.url !~ "/graphql" || !bereq.http.X-Magento-Cache-Id)
+         && bereq.http.cookie !~ "X-Magento-Vary="
+         && beresp.http.set-cookie ~ "X-Magento-Vary=") {
+           set beresp.ttl = 0s;
+           set beresp.uncacheable = true;
+        }
+        unset beresp.http.set-cookie;
+    }
+
+    # If page is not cacheable then bypass varnish for 2 minutes as Hit-For-Pass
+    if (beresp.ttl <= 0s ||
+        beresp.http.Surrogate-control ~ "no-store" ||
+        (!beresp.http.Surrogate-Control &&
+        beresp.http.Cache-Control ~ "no-cache|no-store") ||
+        beresp.http.Vary == "*") {
+        # Mark as Hit-For-Pass for the next 2 minutes
+        set beresp.ttl = 120s;
+        set beresp.uncacheable = true;
+    }
+
+    # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
+    if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
+        set beresp.ttl = 0s;
+        set beresp.uncacheable = true;
+    }
+
+    return (deliver);
+}
+
+sub vcl_deliver {
+    if (obj.uncacheable) {
+        set resp.http.X-Magento-Cache-Debug = "UNCACHEABLE";
+    } else if (obj.hits) {
+        set resp.http.X-Magento-Cache-Debug = "HIT";
+        set resp.http.Grace = req.http.grace;
+    } else {
+        set resp.http.X-Magento-Cache-Debug = "MISS";
+    }
+
+    # Not letting browser to cache non-static files.
+    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(pub/)?(media|static)/") {
+        set resp.http.Pragma = "no-cache";
+        set resp.http.Expires = "-1";
+        set resp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
+    }
+
+    if (!resp.http.X-Magento-Debug) {
+        unset resp.http.Age;
+    }
+    unset resp.http.X-Magento-Debug;
+    unset resp.http.X-Magento-Tags;
+    unset resp.http.X-Powered-By;
+    unset resp.http.Server;
+    unset resp.http.X-Varnish;
+    unset resp.http.Via;
+    unset resp.http.Link;
+}
+
+sub vcl_hit {
+    if (obj.ttl >= 0s) {
+        # Hit within TTL period
+        return (deliver);
+    }
+    if (std.healthy(req.backend_hint)) {
+        if (obj.ttl + {{grace_period}}s > 0s) {
+            # Hit after TTL expiration, but within grace period
+            set req.http.grace = "normal (healthy server)";
+            return (deliver);
+        } else {
+            # Hit after TTL and grace expiration
+            return (restart);
+        }
+    } else {
+        # server is not healthy, retrieve from cache
+        set req.http.grace = "unlimited (unhealthy server)";
+        return (deliver);
+    }
+}


### PR DESCRIPTION
### Added

- Magento 2.4.8+ `Nginx + Varnish + Nginx + PHP-FPM` web stack.
- `php_fpm_development_image` dev-tools service for the FPM stack.
- `php_apache_development_image_8_3` dev-tools service — variant of
  `php_apache_development_image` that tracks the new PHP 8.3+ image tag scheme.

### Changed

- UX: show recommended templates between the choice list and the input prompt.
- Docker image tagging policy for PHP 8.3+: tags now include the web server
  variant — `{version}-{apache|fpm}-{production|development}` (e.g.
  `defaultvalue/php:8.4.19-apache-production`,
  `defaultvalue/php:8.4.19-fpm-development`). PHP ≤ 8.2 images keep the previous
  `{version}-{stage}` scheme.
- Apache service templates `dv_php_apache_8_3.yaml` and
  `dv_php_apache_unsecure_8_3.yaml` reference
  `{{image_version}}-apache-production`.
- Compositions using PHP 8.3+ Apache services (Magento 2.4.7, 2.4.8, 2.4.9)
  reference `php_apache_development_image_8_3`.

### Fixed

- Generated composition `Readme.md` now shows the `/console` path for the Apache
  ActiveMQ Artemis dashboard URL.
- RabbitMQ service template (`dv_rabbitmq.yaml`) volume mount target corrected
  from `/var/lib/mysql` to `/var/lib/rabbitmq`.