### PR TITLE
v3.5.1

### DIFF
--- a/.claude/skills/generating-magento-templates/SKILL.md
+++ b/.claude/skills/generating-magento-templates/SKILL.md
@@ -234,6 +234,15 @@ stack uses `dv_php_apache_unsecure` (SSL terminates at Nginx).
   2.4.6+.
 - OpenSearch: always attach `opensearch_dashboards` dev tool, match dashboard
   version to OpenSearch version.
+- **Elasticsearch 8 does NOT work on Magento 2.4.6 or 2.4.7 — use 7.17** (or
+  OpenSearch), even though the system requirements list ES 8. These lines ship
+  only `Magento_Elasticsearch7`, and the root `composer.json` constraint
+  `~7.17.0 || ~8.17.0` resolves to the 7.17 PHP client — so
+  `--search-engine=elasticsearch8` fails at install with "No alive nodes found
+  in your cluster". Real ES 8 support starts at **2.4.8**
+  (`Magento_Elasticsearch8`). `SetupInstall` derives the `elasticsearch7`/`8`
+  flag from the container's reported version, so keeping 2.4.6/2.4.7 on an ES
+  7.17 container is what makes the install correct.
 - Varnish port: always `80` for modern Varnish (6.x+).
 - RabbitMQ global parameters (`rabbitmq_username`, `rabbitmq_password`,
   `rabbitmq_vhost`) only for 2.4.7+.

--- a/.claude/skills/generating-magento-templates/SKILL.md
+++ b/.claude/skills/generating-magento-templates/SKILL.md
@@ -37,6 +37,27 @@ Each template targets a version range and a web stack type.
    with the previous one. Create a NEW template whenever ANY service's supported
    versions change.
 
+> **Security patches DO change infrastructure requirements — assume they do, not
+> that they don't.** Each Magento patch is re-certified against a specific,
+> tested set of service versions, and a security patch routinely _drops_ a
+> compromised or older version and _requires_ a newer one (the patch's very
+> purpose can be "this build is validated only with Varnish 7.7; 7.6 is no
+> longer supported"). This is precisely why this template set is split so finely
+> per patch — **every existing patch split is a marker that some supported
+> version changed at that patch.** Consequences you must internalize:
+>
+> - A new patch is **never** safe to fold into an existing template's range
+>   without checking the system requirements table first. "It's just a security
+>   patch" is a reason to check _more_ carefully, not less.
+> - An existing constraint already _matching_ a new patch (e.g. `<2.4.7` covers
+>   `2.4.6-p15`) does **not** mean the template is _correct_ for it — it means
+>   the tool will silently build a stale/wrong version set until you verify.
+>   Coverage ≠ correctness.
+> - The authoritative "what we last verified" marker is the version list in
+>   `src/Console/Command/Magento/TestTemplates.php`. If a released patch is
+>   newer than the top boundary there, it is untested — treat the template as
+>   potentially wrong for that patch until re-checked and re-tested.
+
 ### Per-Patch Comparison Process
 
 For each patch, check ALL of these against the previous patch:
@@ -216,3 +237,9 @@ stack uses `dv_php_apache_unsecure` (SSL terminates at Nginx).
 - Varnish port: always `80` for modern Varnish (6.x+).
 - RabbitMQ global parameters (`rabbitmq_username`, `rabbitmq_password`,
   `rabbitmq_vhost`) only for 2.4.7+.
+- Nginx templates set `nginx_version` once in the composition's global
+  `app.parameters` block (not per-service) — both Nginx services
+  (`dv_nginx_proxy_for_varnish`, `dv_nginx_magento_for_fpm`) read it from there,
+  so the two-Nginx PHP-FPM stack isn't duplicated. There is no default, so a
+  missing value makes composition generation throw. Pin the real version for new
+  templates (e.g. `'1.30'`); older, not-yet-analyzed templates use `latest`.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,6 +1,9 @@
 config:
   # Prettier handles line length
   MD013: false
+  # Prettier indents nested list items by 4 and runs last in lint-staged
+  MD007:
+    indent: 4
   # Allow duplicate headings in different sections
   MD024:
     siblings_only: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Magento **2.4.6-p15**, **2.4.7-p10**, and **2.4.8-p5** composition templates.
+  Each of these May 2026 security patches changed the supported infrastructure
+  versions, so each is split into its own template from the previous patch
+  range.
+- Magento **2.4.9** GA templates (`_p0`) across all three web stacks, replacing
+  the earlier `2.4.9-beta1` drafts.
+- `nginx_version` parameter for Nginx templates, set once in the composition's
+  global `app.parameters` (both Nginx services read it from there). New
+  templates (2.4.6-p15 and later) pin nginx `1.30`; every existing Nginx
+  template sets it explicitly to `latest` (to be pinned per version later).
+
+### Changed
+
+- Varnish upgraded to **8.0** for 2.4.6-p15, 2.4.7-p10, 2.4.8-p5, and 2.4.9
+  (Adobe system-requirement change). Magento ships no separate Varnish 8 VCL, so
+  the existing `varnish7.vcl`-based configuration is reused.
+- Ported the upstream `varnish7.vcl` tracking-parameter regex update
+  (`gad_source` → the broader `gad_[a-z]+`) into `varnish_magento_v7.vcl`.
+- Per-patch supported-service changes (from the Adobe system requirements
+  table):
+    - **2.4.6-p15**: removed Elasticsearch, MySQL, and Redis; added OpenSearch
+      3; Valkey 8 → 8.1.
+    - **2.4.7-p10**: removed MySQL and Redis; Elasticsearch 7.17 → 8.17; added
+      OpenSearch 3 and MariaDB 11.8; Valkey 8 → 8.1; RabbitMQ 4.1 → 4.2.
+    - **2.4.8-p5**: added MariaDB 11.8; Valkey 8 → 8.1; RabbitMQ 4.1 → 4.2.
+    - **2.4.9**: PHP 8.5, MariaDB 12.3, MySQL 8.4, OpenSearch 3.7.0, Valkey 9,
+      RabbitMQ 4.2 (no Elasticsearch, no Redis).
+
 ## [3.5.0] - 2026-05-13
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,29 @@ and this project adheres to
     - **2.4.9**: PHP 8.5, MariaDB 12.3, MySQL 8.4, OpenSearch 3.7.0, Valkey 9,
       RabbitMQ 4.2 (no Elasticsearch, no Redis).
 
+### Fixed
+
+- Test harness (`magento:test-templates` and other multithread tests) now logs
+  the actual cause of a failed run. `logThrowable()` rendered the exception via
+  `Application::renderThrowable()`, which produces no output from a forked
+  worker, so every failure logged only `FAILED! …` followed by a blank line.
+  Failed shell/container commands (the common case — `grunt`, `npm`,
+  `bin/magento …`) now log a compact entry — the command, why it failed, and its
+  captured stdout/stderr — without the noisy framework backtrace. Timeouts also
+  record the exit code and any partial output printed before the command hung.
+  Only genuinely unexpected exceptions log the full cause chain and backtrace.
+- `magento:test-templates` now retries `deploy:mode:set developer` (the "Test
+  Grunt" step) a few times before failing. Switching to developer mode wipes
+  `generated/`, which intermittently fails on the macOS Docker bind mount with
+  `rmdir(...): Directory not empty` - a race with the filesystem or with an
+  in-flight Varnish health probe regenerating code. Timeouts are not retried.
+- `setup:install` now derives the `--search-engine=elasticsearch7|8` flag from
+  the running Elasticsearch container (new `Elasticsearch::getMajorVersion()`)
+  instead of the Magento version. A version that supports both engines - e.g.
+  2.4.7-p10 ships Elasticsearch 8 while still being `< 2.4.8` - was installed
+  against the wrong, protocol-incompatible engine (`elasticsearch7` vs an ES8
+  container).
+
 ## [3.5.0] - 2026-05-13
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,30 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1]
 
 ### Added
 
 - Magento **2.4.6-p15**, **2.4.7-p10**, and **2.4.8-p5** composition templates.
-  Each of these May 2026 security patches changed the supported infrastructure
-  versions, so each is split into its own template from the previous patch
-  range.
-- Magento **2.4.9** GA templates (`_p0`) across all three web stacks, replacing
-  the earlier `2.4.9-beta1` drafts.
-- `nginx_version` parameter for Nginx templates, set once in the composition's
-  global `app.parameters` (both Nginx services read it from there). New
-  templates (2.4.6-p15 and later) pin nginx `1.30`; every existing Nginx
-  template sets it explicitly to `latest` (to be pinned per version later).
+- Magento **2.4.9** GA templates (`_p0`), replacing the `2.4.9-beta1` drafts.
+- `nginx_version` parameter, set once in the composition's global
+  `app.parameters`. Templates from 2.4.6-p15 on pin nginx `1.30`; older ones use
+  `latest`.
 
 ### Changed
 
-- Varnish upgraded to **8.0** for 2.4.6-p15, 2.4.7-p10, 2.4.8-p5, and 2.4.9
-  (Adobe system-requirement change). Magento ships no separate Varnish 8 VCL, so
-  the existing `varnish7.vcl`-based configuration is reused.
+- Varnish upgraded to **8.0** for 2.4.6-p15, 2.4.7-p10, 2.4.8-p5, and 2.4.9,
+  reusing the existing `varnish7.vcl` configuration.
 - Ported the upstream `varnish7.vcl` tracking-parameter regex update
-  (`gad_source` → the broader `gad_[a-z]+`) into `varnish_magento_v7.vcl`.
-- Per-patch supported-service changes (from the Adobe system requirements
-  table):
+  (`gad_source` → `gad_[a-z]+`) into `varnish_magento_v7.vcl`.
+- Per-patch supported-service changes:
     - **2.4.6-p15**: removed Elasticsearch, MySQL, and Redis; added OpenSearch
       3; Valkey 8 → 8.1.
     - **2.4.7-p10**: removed MySQL and Redis; Elasticsearch 7.17 → 8.17; added
@@ -37,29 +30,24 @@ and this project adheres to
     - **2.4.8-p5**: added MariaDB 11.8; Valkey 8 → 8.1; RabbitMQ 4.1 → 4.2.
     - **2.4.9**: PHP 8.5, MariaDB 12.3, MySQL 8.4, OpenSearch 3.7.0, Valkey 9,
       RabbitMQ 4.2 (no Elasticsearch, no Redis).
+- Composer and npm dependencies updated, including the PHP_CodeSniffer 3 → 4 and
+  Guzzle 7 → 8 major bumps.
+
+### Removed
+
+- Unused `Docker\Network` dependency from `Docker\Compose`.
 
 ### Fixed
 
 - Test harness (`magento:test-templates` and other multithread tests) now logs
-  the actual cause of a failed run. `logThrowable()` rendered the exception via
-  `Application::renderThrowable()`, which produces no output from a forked
-  worker, so every failure logged only `FAILED! …` followed by a blank line.
-  Failed shell/container commands (the common case — `grunt`, `npm`,
-  `bin/magento …`) now log a compact entry — the command, why it failed, and its
-  captured stdout/stderr — without the noisy framework backtrace. Timeouts also
-  record the exit code and any partial output printed before the command hung.
-  Only genuinely unexpected exceptions log the full cause chain and backtrace.
-- `magento:test-templates` now retries `deploy:mode:set developer` (the "Test
-  Grunt" step) a few times before failing. Switching to developer mode wipes
-  `generated/`, which intermittently fails on the macOS Docker bind mount with
-  `rmdir(...): Directory not empty` - a race with the filesystem or with an
-  in-flight Varnish health probe regenerating code. Timeouts are not retried.
+  the actual cause of a failed run — the command, why it failed, and its output
+  — instead of a bare `FAILED!` line.
+- `magento:test-templates` now retries `deploy:mode:set developer`, which
+  intermittently fails on the macOS Docker bind mount with
+  `rmdir(...): Directory not empty`.
 - `setup:install` now derives the `--search-engine=elasticsearch7|8` flag from
-  the running Elasticsearch container (new `Elasticsearch::getMajorVersion()`)
-  instead of the Magento version. A version that supports both engines - e.g.
-  2.4.7-p10 ships Elasticsearch 8 while still being `< 2.4.8` - was installed
-  against the wrong, protocol-incompatible engine (`elasticsearch7` vs an ES8
-  container).
+  the running Elasticsearch container instead of the Magento version, which
+  picked the wrong engine for releases supporting both (e.g. 2.4.7-p10).
 
 ## [3.5.0] - 2026-05-13
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "defaultvalue/dockerizer_for_php",
     "description": "Docker-based development for PHP projects with transparent Docker configurations.",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "type": "project",
     "authors": [{
         "name": "Maksym Zaporozhets",
@@ -31,13 +31,13 @@
         "composer/semver": "~3.4.0",
         "symfony/http-client": "~7.4.0",
         "monolog/monolog": "~3.10.0",
-        "aws/aws-sdk-php": "~3.376.0",
+        "aws/aws-sdk-php": "~3.389.0",
         "yosymfony/toml": "~1.0.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "~3.13.0",
-        "phpstan/phpstan": "~2.1.0"
+        "squizlabs/php_codesniffer": "~4.0.0",
+        "phpstan/phpstan": "~2.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f1155c3593d01832f11d06533d37caf",
+    "content-hash": "c0e6733efea17308b12229d08f18e7fa",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.376.3",
+            "version": "3.389.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2081f8db174df4bb8842aed3b7b513590ee9d219"
+                "reference": "784e0fb95e752e55c4654b5800b900c78f6d3990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2081f8db174df4bb8842aed3b7b513590ee9d219",
-                "reference": "2081f8db174df4bb8842aed3b7b513590ee9d219",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/784e0fb95e752e55c4654b5800b900c78f6d3990",
+                "reference": "784e0fb95e752e55c4654b5800b900c78f6d3990",
                 "shasum": ""
             },
             "require": {
@@ -79,10 +79,10 @@
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/promises": "^2.0",
-                "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.8.0",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+                "mtdowling/jmespath.php": "^2.9.1",
                 "php": ">=8.1",
                 "psr/http-message": "^1.0 || ^2.0",
                 "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.376.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.389.2"
             },
-            "time": "2026-04-03T18:07:33+00:00"
+            "time": "2026-07-28T18:10:25+00:00"
         },
         {
             "name": "composer/semver",
@@ -236,25 +236,27 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "3aeea0406aab88cbbd86531313d7cebf8ae149a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3aeea0406aab88cbbd86531313d7cebf8ae149a4",
+                "reference": "3aeea0406aab88cbbd86531313d7cebf8ae149a4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
-                "php": "^7.2.5 || ^8.0",
+                "guzzlehttp/promises": "^3.0",
+                "guzzlehttp/psr7": "^3.0",
+                "php": "^7.4 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "psr/http-factory": "^1.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -262,9 +264,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "4.0.1",
+                "guzzlehttp/test-server": "^1.0",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -280,9 +283,6 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -342,7 +342,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/8.0.1"
             },
             "funding": [
                 {
@@ -358,28 +358,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-26T23:23:24+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/d961a21387cd680ec1cc6f52aa1fdcef33105e24",
+                "reference": "d961a21387cd680ec1cc6f52aa1fdcef33105e24",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -425,7 +425,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/3.0.0"
             },
             "funding": [
                 {
@@ -441,37 +441,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-07-20T13:44:17+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "php": "^7.4 || ^8.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^2.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
             },
             "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
+                "psr/http-factory-implementation": "1.1",
+                "psr/http-message-implementation": "2.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "php-http/psr7-integration-tests": "^1.5.1",
+                "phpunit/phpunit": "^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -542,7 +544,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
             },
             "funding": [
                 {
@@ -558,7 +560,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-07-20T13:48:31+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -665,16 +667,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
                 "shasum": ""
             },
             "require": {
@@ -683,7 +685,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -691,7 +693,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -725,9 +727,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "psr/container",
@@ -993,61 +995,17 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
             "name": "symfony/config",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b"
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2d19dde43fa2ff720b9a40763ace7226594f503b",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
                 "shasum": ""
             },
             "require": {
@@ -1093,7 +1051,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.8"
+                "source": "https://github.com/symfony/config/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1113,20 +1071,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-09T07:51:57+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -1191,7 +1149,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1211,20 +1169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d"
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7025fd7b687c240426562f86ada06a93b1e771d",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
                 "shasum": ""
             },
             "require": {
@@ -1275,7 +1233,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1295,20 +1253,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T06:50:29+00:00"
+            "time": "2026-06-24T07:41:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -1321,7 +1279,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1346,7 +1304,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -1358,24 +1316,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "5df79f11350166125fe754c85b87f7e13d735314"
+                "reference": "9b9c7a00e565238857eea0040dc9745e3576402e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/5df79f11350166125fe754c85b87f7e13d735314",
-                "reference": "5df79f11350166125fe754c85b87f7e13d735314",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/9b9c7a00e565238857eea0040dc9745e3576402e",
+                "reference": "9b9c7a00e565238857eea0040dc9745e3576402e",
                 "shasum": ""
             },
             "require": {
@@ -1420,7 +1382,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v7.4.8"
+                "source": "https://github.com/symfony/dotenv/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1440,20 +1402,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T12:55:43+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.8",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/58b9790d12f9670b7f53a1c1738febd3108970a5",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -1490,7 +1452,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.8"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -1510,20 +1472,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -1558,7 +1520,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1578,20 +1540,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "01933e626c3de76bea1e22641e205e78f6a34342"
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/01933e626c3de76bea1e22641e205e78f6a34342",
-                "reference": "01933e626c3de76bea1e22641e205e78f6a34342",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
                 "shasum": ""
             },
             "require": {
@@ -1659,7 +1621,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1679,20 +1641,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T12:55:43+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
                 "shasum": ""
             },
             "require": {
@@ -1705,7 +1667,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1741,7 +1703,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -1753,24 +1715,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -1820,7 +1786,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1840,20 +1806,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
                 "shasum": ""
             },
             "require": {
@@ -1902,7 +1868,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
             },
             "funding": [
                 {
@@ -1922,20 +1888,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-07-28T08:25:59+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -1987,7 +1953,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -2007,20 +1973,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2072,7 +2038,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2092,20 +2058,184 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6",
                 "shasum": ""
             },
             "require": {
@@ -2152,7 +2282,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.41.0"
             },
             "funding": [
                 {
@@ -2172,20 +2302,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-07-01T12:47:55+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -2217,7 +2347,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -2237,20 +2367,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -2268,7 +2398,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2304,7 +2434,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2324,20 +2454,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -2395,7 +2525,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -2415,20 +2545,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "398907e89a2a56fe426f7955c6fa943ec0c77225"
+                "reference": "0118811b1d59f323bf131250b3fb919febfece28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/398907e89a2a56fe426f7955c6fa943ec0c77225",
-                "reference": "398907e89a2a56fe426f7955c6fa943ec0c77225",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0118811b1d59f323bf131250b3fb919febfece28",
+                "reference": "0118811b1d59f323bf131250b3fb919febfece28",
                 "shasum": ""
             },
             "require": {
@@ -2476,7 +2606,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2496,20 +2626,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:41:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
                 "shasum": ""
             },
             "require": {
@@ -2552,7 +2682,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2572,7 +2702,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "yosymfony/parser-utils",
@@ -2688,11 +2818,11 @@
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.46",
+            "version": "2.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
-                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
+                "reference": "a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
                 "shasum": ""
             },
             "require": {
@@ -2714,6 +2844,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -2737,7 +2878,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-01T09:25:14+00:00"
+            "time": "2026-07-26T21:22:49+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -2745,18 +2886,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "db78064456eb735e368677828095fb7fe5aeda6f"
+                "reference": "e0739cf6f94302acbdfb1807731568a47830bb4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/db78064456eb735e368677828095fb7fe5aeda6f",
-                "reference": "db78064456eb735e368677828095fb7fe5aeda6f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e0739cf6f94302acbdfb1807731568a47830bb4d",
+                "reference": "e0739cf6f94302acbdfb1807731568a47830bb4d",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adaptcms/adaptcms": "<=1.3",
-                "admidio/admidio": "<5.0.8",
+                "adawolfa/isdoc": "<1.4.3|>=1.5,<1.5.1|>=1.6,<1.6.1",
+                "admidio/admidio": "<=5.0.11",
                 "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
@@ -2767,12 +2909,14 @@
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-laravel": "==2021.10",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
+                "aimeos/pagible": "<0.10.4",
                 "airesvsg/acf-to-rest-api": "<=3.1",
                 "akaunting/akaunting": "<2.1.13",
                 "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
                 "alextselegidis/easyappointments": "<=1.5.2",
                 "alexusmai/laravel-file-manager": "<=3.3.1",
                 "algolia/algoliasearch-magento-2": "<=3.16.1|>=3.17.0.0-beta1,<=3.17.1",
+                "almirhodzic/nova-toggle-5": "<1.3",
                 "alt-design/alt-redirect": "<1.6.4",
                 "altcha-org/altcha": "<1.3.1",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
@@ -2788,8 +2932,10 @@
                 "aoe/restler": "<1.7.1",
                 "apache-solr-for-typo3/solr": "<2.8.3",
                 "apereo/phpcas": "<1.6",
-                "api-platform/core": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/core": "<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
                 "api-platform/graphql": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/hal": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
+                "api-platform/json-api": ">=4,<4.1.29|>=4.2,<4.2.25|>=4.3,<4.3.8",
                 "appwrite/server-ce": "<=1.2.1",
                 "arc/web": "<3",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
@@ -2802,22 +2948,21 @@
                 "austintoddj/canvas": "<=3.4.2",
                 "auth0/auth0-php": ">=3.3,<=8.18",
                 "auth0/login": "<=7.20",
-                "auth0/symfony": "<=5.7",
+                "auth0/symfony": "<=5.8",
                 "auth0/wordpress": "<=5.5",
-                "automad/automad": "<2.0.0.0-alpha5",
+                "automad/automad": "<=2.0.0.0-beta27",
                 "automattic/jetpack": "<9.8",
-                "avideo/avideo": "<=26",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": "<=3.371.3",
                 "ayacoo/redirect-tab": "<2.1.2|>=3,<3.1.7|>=4,<4.0.5",
-                "azuracast/azuracast": "<=0.23.3",
+                "azuracast/azuracast": "<=0.23.5",
                 "b13/seo_basics": "<0.8.2",
                 "backdrop/backdrop": "<=1.32",
-                "backpack/crud": "<3.4.9",
+                "backpack/crud": "<4.0.63|>=4.1,<4.1.69|>=5,<5.0.13",
                 "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
                 "bacula-web/bacula-web": "<9.7.1",
                 "badaso/core": "<=2.9.11",
-                "bagisto/bagisto": "<2.3.10",
+                "bagisto/bagisto": "<=2.3.15",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
                 "barryvdh/laravel-translation-manager": "<0.6.8",
@@ -2830,6 +2975,7 @@
                 "bedita/bedita": "<4",
                 "bednee/cooluri": "<1.0.30",
                 "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billabear/billabear": "<=2025.01.03",
                 "billz/raspap-webgui": "<3.3.6",
                 "binarytorch/larecipe": "<2.8.1",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
@@ -2850,13 +2996,14 @@
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cadmium-org/cadmium-cms": "<=0.4.9",
-                "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10|>=5.2.10,<5.2.12|==5.3",
+                "cakephp/authentication": "<3.3.6|>=4,<4.1.1",
+                "cakephp/cakephp": "<4.5.11|>=4.6,<4.6.4|>=5,<5.1.7|>=5.2,<5.2.13|>=5.3,<5.3.6",
                 "cakephp/database": ">=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
                 "cardgate/magento2": "<2.0.33",
                 "cardgate/woocommerce": "<=3.1.15",
-                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cart2quote/module-quotation": ">=4.1.6,<4.4.6|>=5,<5.4.4",
                 "cart2quote/module-quotation-encoded": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<=2.1.6",
+                "cartalyst/sentry": "<2.1.7",
                 "catfan/medoo": "<1.7.5",
                 "causal/oidc": "<4",
                 "cecil/cecil": "<7.47.1",
@@ -2865,41 +3012,42 @@
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
                 "chrome-php/chrome": "<1.14",
-                "ci4-cms-erp/ci4ms": "<=0.28.6",
+                "ci4-cms-erp/ci4ms": "<=0.31.8",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
                 "co-stack/fal_sftp": "<0.2.6",
-                "cockpit-hq/cockpit": "<2.13.5",
-                "code16/sharp": "<9.20",
+                "cockpit-hq/cockpit": "<=2.14",
+                "code16/sharp": "<9.22.3",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
-                "codeigniter4/framework": "<4.6.2",
+                "codeigniter4/framework": "<4.7.2",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
                 "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
                 "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
-                "composer/composer": "<1.10.27|>=2,<2.2.26|>=2.3,<2.9.3",
-                "concrete5/concrete5": "<9.4.8",
+                "composer/composer": "<2.2.29|>=2.3,<2.10.2",
+                "concrete5/concrete5": "<9.5.2",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
-                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<4.13.56|>=5,<5.3.38|>=5.4.0.0-RC1-dev,<5.6.1",
+                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<5.3.48|>=5.4,<5.7.9",
                 "contao/core": "<3.5.39",
-                "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
+                "contao/core-bundle": "<5.3.48|>=5.4,<5.7.9",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "coreshop/core-shop": "<4.1.9",
+                "coreshop/core-shop": "<4.1.9|==5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
+                "cotonti/cotonti": "<=1",
                 "couleurcitron/tarteaucitron-wp": "<0.3",
                 "cpsit/typo3-mailqueue": "<0.4.5|>=0.5,<0.5.2",
                 "craftcms/aws-s3": ">=2.0.2,<=2.2.4",
                 "craftcms/azure-blob": ">=2.0.0.0-beta1,<=2.1",
-                "craftcms/cms": "<=4.17.7|>=5,<=5.9.13",
-                "craftcms/commerce": ">=4,<4.11|>=5,<5.6",
+                "craftcms/cms": "<4.18|>=5,<5.10",
+                "craftcms/commerce": ">=4,<=4.11.1|>=5,<=5.6.4",
                 "craftcms/composer": ">=4.0.0.0-RC1-dev,<=4.10|>=5.0.0.0-RC1-dev,<=5.5.1",
                 "craftcms/craft": ">=3.5,<=4.16.17|>=5.0.0.0-RC1-dev,<=5.8.21",
                 "craftcms/google-cloud": ">=2.0.0.0-beta1,<=2.2",
@@ -2917,6 +3065,7 @@
                 "david-garcia/phpwhois": "<=4.3.1",
                 "dbrisinajumi/d2files": "<1",
                 "dcat/laravel-admin": "<=2.1.3|==2.2.0.0-beta|==2.2.2.0-beta",
+                "dedoc/scramble": ">=0.13.2,<0.13.22",
                 "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
                 "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1|>=7,<7.4",
                 "desperado/xml-bundle": "<=0.1.7",
@@ -2938,8 +3087,8 @@
                 "doctrine/mongodb-odm": "<1.0.2",
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<=22.0.4",
-                "dompdf/dompdf": "<2.0.4",
+                "dolibarr/dolibarr": "<=23.0.2",
+                "dompdf/dompdf": "<3.1.6",
                 "doublethreedigital/guest-entries": "<3.1.2",
                 "dreamfactory/df-core": "<1.0.4",
                 "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
@@ -2953,7 +3102,7 @@
                 "drupal/commerce_alphabank_redirect": "<1.0.3",
                 "drupal/commerce_eurobank_redirect": "<2.1.1",
                 "drupal/config_split": "<1.10|>=2,<2.0.2",
-                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.4.9|>=10.5,<10.5.6|>=11,<11.1.9|>=11.2,<11.2.8",
+                "drupal/core": ">=6,<6.38|>=7,<7.103|>=8,<10.5.10|>=10.6,<10.6.9|>=11,<11.2.12|>=11.3,<11.3.10",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
                 "drupal/currency": "<3.5",
                 "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
@@ -2980,10 +3129,11 @@
                 "drupal/umami_analytics": "<1.0.1",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.10|>=5,<5.0.13",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
-                "egroupware/egroupware": "<23.1.20260113|>=26.0.20251208,<26.0.20260113",
+                "egroupware/egroupware": "<23.1.20260601|>=26.0.20251208,<26.5.20260507",
                 "elefant/cms": "<2.0.7",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "elijaa/phpmemcacheadmin": "<=1.3",
@@ -2995,6 +3145,7 @@
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
                 "evolutioncms/evolution": "<=3.2.3",
+                "evoweb/sf-register": "<13.2.4|>=14,<14.0.2",
                 "exceedone/exment": "<4.4.3|>=5,<5.0.3",
                 "exceedone/laravel-admin": "<2.2.3|==3",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1-dev",
@@ -3017,15 +3168,16 @@
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1-dev|>=2.5,<2.5.15",
                 "ezyang/htmlpurifier": "<=4.2",
                 "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
-                "facturascripts/facturascripts": "<2025.81",
+                "facturascripts/facturascripts": "<=2026.2",
                 "fastly/magento2": "<1.2.26",
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
-                "filament/actions": ">=3.2,<3.2.123",
-                "filament/filament": ">=4,<4.3.1",
-                "filament/infolists": ">=3,<3.2.115",
-                "filament/tables": ">=3,<3.2.115|>=4,<4.8.5|>=5,<5.3.5",
+                "filament/actions": ">=3.2,<3.2.123|>=4,<=4.11.3|>=5,<=5.6.3",
+                "filament/filament": ">=3,<=3.3.51|>=4,<4.11.5|>=5,<5.6.5",
+                "filament/forms": ">=3,<=3.3.52",
+                "filament/infolists": ">=3,<3.2.115|>=4,<=4.11.4|>=5,<=5.6.4",
+                "filament/tables": ">=3,<=3.3.50|>=4,<=4.11.4|>=5,<=5.6.4",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -3033,13 +3185,14 @@
                 "fisharebest/webtrees": "<=2.1.18",
                 "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
                 "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
-                "flarum/core": "<1.8.10",
+                "flarum/core": "<=1.8.15|>=2.0.0.0-beta1,<=2.0.0.0-beta8",
                 "flarum/flarum": "<0.1.0.0-beta8",
                 "flarum/framework": "<1.8.10",
                 "flarum/mentions": "<1.6.3",
                 "flarum/nicknames": "<1.8.3",
                 "flarum/sticky": ">=0.1.0.0-beta14,<=0.1.0.0-beta15",
                 "flarum/tags": "<=0.1.0.0-beta13",
+                "flightphp/core": "<3.18.1",
                 "floriangaerber/magnesium": "<0.3.1",
                 "fluidtypo3/vhs": "<5.1.1",
                 "fof/byobu": ">=0.3.0.0-beta2,<1.1.7",
@@ -3058,19 +3211,22 @@
                 "friendsofsymfony1/symfony1": ">=1.1,<1.5.19",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
+                "friendsoftypo3/tt-address": "<8.1.2|>=9,<9.1.1|>=10,<10.0.1",
                 "froala/wysiwyg-editor": "<=4.3",
                 "frosh/adminer-platform": "<2.2.1",
-                "froxlor/froxlor": "<=2.3.4",
+                "froxlor/froxlor": "<2.3.7",
                 "frozennode/administrator": "<=5.0.12",
                 "fuel/core": "<1.8.1",
-                "funadmin/funadmin": "<=7.1.0.0-RC4",
+                "funadmin/funadmin": "<=7.1.0.0-RC6",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
-                "georgringer/news": "<1.3.3",
+                "georgringer/news": "<10.0.4|>=11,<11.4.4|>=12,<12.3.2|>=13,<13.0.2|>=14,<14.0.3",
                 "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<=2.3.3",
-                "getgrav/grav": "<1.11.0.0-beta1",
-                "getkirby/cms": "<=5.2.1",
+                "getgrav/grav": "<=2.0.0.0-RC8",
+                "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
+                "getgrav/grav-plugin-form": "<9.1",
+                "getkirby/cms": "<=4.9.3|>=5,<=5.4.3",
                 "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
@@ -3079,16 +3235,18 @@
                 "globalpayments/php-sdk": "<2",
                 "goalgorilla/open_social": "<12.3.11|>=12.4,<12.4.10|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
                 "gogentooss/samlbase": "<1.2.7",
+                "goodoneuz/pay-uz": "<=2.2.24",
                 "google/protobuf": "<4.33.6",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gp247/core": "<1.1.24",
                 "gree/jose": "<2.2.1",
                 "gregwar/rst": "<1.0.3",
-                "grumpydictator/firefly-iii": "<6.1.17|>=6.4.23,<=6.5",
+                "grumpydictator/firefly-iii": "<=6.6.2",
                 "gugoan/economizzer": "<=0.9.0.0-beta1",
-                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/guzzle": "<7.15.1",
+                "guzzlehttp/guzzle-services": "<1.5.4",
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
-                "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
+                "guzzlehttp/psr7": "<2.12.3",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
                 "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
@@ -3117,6 +3275,7 @@
                 "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<6.18.31|>=7,<7.22.4",
                 "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
                 "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/mail": ">=9,<12.60|>=13,<13.10",
                 "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "imdbphp/imdbphp": "<=5.1.1",
                 "impresscms/impresscms": "<=1.4.5",
@@ -3128,8 +3287,9 @@
                 "innologi/typo3-appointments": "<2.0.6",
                 "intelliants/subrion": "<4.2.2",
                 "inter-mediator/inter-mediator": "==5.5",
+                "intercom/intercom-php": "==5.0.2",
                 "invoiceninja/invoiceninja": "<5.13.4",
-                "ipl/web": "<0.10.1",
+                "ipl/web": "<=0.10.2|>=0.11,<=0.13",
                 "islandora/crayfish": "<4.1",
                 "islandora/islandora": ">=2,<2.4.1",
                 "ivankristianto/phpwhois": "<=4.3",
@@ -3141,6 +3301,8 @@
                 "jasig/phpcas": "<1.3.3",
                 "jbartels/wec-map": "<3.0.3",
                 "jcbrand/converse.js": "<3.3.3",
+                "jleehr/canto-saas-api": "<=2",
+                "joedolson/my-calendar": "<3.7.7",
                 "joelbutcher/socialstream": "<5.6|>=6,<6.2",
                 "johnbillion/query-monitor": "<3.20.4",
                 "johnbillion/wp-crontrol": "<1.16.2|>=1.17,<1.19.2",
@@ -3160,29 +3322,32 @@
                 "juzaweb/cms": "<=3.4.2",
                 "jweiland/events2": "<8.3.8|>=9,<9.0.6",
                 "jweiland/kk-downloader": "<1.2.2",
+                "kantorge/yaffa": "<=2",
                 "kazist/phpwhois": "<=4.2.6",
                 "kelvinmo/simplejwt": "<=1.1",
                 "kelvinmo/simplexrd": "<3.1.1",
                 "kevinpapst/kimai2": "<1.16.7",
-                "khodakhah/nodcms": "<=3",
-                "kimai/kimai": "<=2.50",
+                "khodakhah/nodcms": "<=3.4.1",
+                "kimai/kimai": "<2.59",
                 "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
                 "klaviyo/magento2-extension": ">=1,<3",
-                "knplabs/knp-snappy": "<=1.4.2",
+                "knplabs/knp-snappy": "<=1.7",
                 "kohana/core": "<3.3.3",
                 "koillection/koillection": "<1.6.12",
                 "krayin/laravel-crm": "<=2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "kumbiaphp/kumbiapp": "<=1.1.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
+                "laktak/hjson": "<2.3",
                 "laminas/laminas-diactoros": "<2.18.1|==2.19|==2.20|==2.21|==2.22|==2.23|>=2.24,<2.24.2|>=2.25,<2.25.2",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
                 "lara-zeus/artemis": ">=1,<=1.0.6",
                 "lara-zeus/dynamic-dashboard": ">=3,<=3.0.1",
                 "laravel/fortify": "<1.11.1",
-                "laravel/framework": "<10.48.29|>=11,<11.44.1|>=12,<12.1.1",
+                "laravel/framework": "<12.61.1|>=13,<13.12",
                 "laravel/laravel": ">=5.4,<5.4.22",
+                "laravel/passport": ">=13,<13.7.1",
                 "laravel/pulse": "<1.3.1",
                 "laravel/reverb": "<1.7",
                 "laravel/socialite": ">=1,<2.0.10",
@@ -3222,20 +3387,23 @@
                 "maikuolan/phpmussel": ">=1,<1.6",
                 "mainwp/mainwp": "<=4.4.3.3",
                 "manogi/nova-tiptap": "<=3.2.6",
-                "mantisbt/mantisbt": "<2.28.1",
+                "mantisbt/mantisbt": "<=2.28.3",
                 "marcwillmann/turn": "<0.3.3",
+                "markhuot/craftql": "<=1.3.7",
                 "marshmallow/nova-tiptap": "<5.7",
                 "matomo/matomo": "<1.11",
                 "matyhtf/framework": "<3.0.6",
-                "mautic/core": "<5.2.10|>=6,<6.0.8|>=7.0.0.0-alpha,<7.0.1",
+                "mautic/core": "<5.2.11|>=6,<6.0.9|>=7,<7.1.2",
                 "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "mautic/grapes-js-builder-bundle": ">=4,<4.4.18|>=5,<5.2.9|>=6,<6.0.7",
                 "maximebf/debugbar": "<1.19",
+                "mckenziearts/livewire-markdown-editor": "<1.3",
                 "mdanter/ecc": "<2",
                 "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
                 "mediawiki/cargo": "<3.8.3",
                 "mediawiki/core": "<1.39.5|==1.40",
                 "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
+                "mediawiki/maps": "<12.1.3",
                 "mediawiki/matomo": "<2.4.3",
                 "mediawiki/semantic-media-wiki": "<4.0.2",
                 "mehrwert/phpmyadmin": "<3.2",
@@ -3255,6 +3423,8 @@
                 "miniorange/miniorange-saml": "<1.4.3",
                 "miraheze/ts-portal": "<=33",
                 "mittwald/typo3_forum": "<1.2.1",
+                "mix/mix": ">=2,<=2.2.17",
+                "mmc/ceselector": "<3.0.3|>=4,<4.0.2|>=5,<5.0.1|>=6,<6.0.1",
                 "mobiledetect/mobiledetectlib": "<2.8.32",
                 "modx/revolution": "<=3.1",
                 "mojo42/jirafeau": "<4.4",
@@ -3267,6 +3437,7 @@
                 "movim/moxl": ">=0.8,<=0.10",
                 "movingbytes/social-network": "<=1.2.1",
                 "mpdf/mpdf": "<=7.1.7",
+                "mtdowling/jmespath.php": "<2.9.1",
                 "munkireport/comment": "<4",
                 "munkireport/managedinstalls": "<2.6",
                 "munkireport/munki_facts": "<1.5",
@@ -3274,6 +3445,7 @@
                 "munkireport/softwareupdate": "<1.6",
                 "mustache/mustache": ">=2,<2.14.1",
                 "mwdelaney/wp-enable-svg": "<=0.2",
+                "nabeel/phpvms": "<7.0.6",
                 "namshi/jose": "<2.2",
                 "nasirkhan/laravel-starter": "<11.11",
                 "nategood/httpful": "<1",
@@ -3293,20 +3465,20 @@
                 "nilsteampassnet/teampass": "<3.1.3.1-dev",
                 "nitsan/ns-backup": "<13.0.1",
                 "nonfiction/nterchange": "<4.1.1",
-                "notrinos/notrinos-erp": "<=0.7",
+                "notrinos/notrinos-erp": "<=1",
                 "noumo/easyii": "<=0.9",
                 "novaksolutions/infusionsoft-php-sdk": "<1",
                 "novosga/novosga": "<=2.2.12",
-                "nukeviet/nukeviet": "<4.5.02",
+                "nukeviet/nukeviet": "<4.6.00",
                 "nyholm/psr7": "<1.6.1",
                 "nystudio107/craft-seomatic": "<3.4.12",
                 "nzedb/nzedb": "<0.8",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
                 "october/backend": "<1.1.2",
                 "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
-                "october/october": "<3.7.5",
-                "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<=3.7.12|>=4,<=4.0.11",
+                "october/october": "<3.7.14|>=4,<4.1.10",
+                "october/rain": "<=3.7.13|>=4,<=4.1.9",
+                "october/system": "<3.7.16|>=4,<4.1.16",
                 "oliverklee/phpunit": "<3.5.15",
                 "omeka/omeka-s": "<4.0.3",
                 "onelogin/php-saml": "<2.21.1|>=3,<3.8.1|>=4,<4.3.1",
@@ -3314,7 +3486,7 @@
                 "open-web-analytics/open-web-analytics": "<1.8.1",
                 "opencart/opencart": ">=0",
                 "openid/php-openid": "<2.3",
-                "openmage/magento-lts": "<20.16.1",
+                "openmage/magento-lts": "<=20.17",
                 "opensolutions/vimbadmin": "<=3.0.15",
                 "opensource-workshop/connect-cms": "<1.41.1|>=2,<2.41.1",
                 "orchid/platform": ">=8,<14.43",
@@ -3335,6 +3507,7 @@
                 "paragonie/random_compat": "<2",
                 "paragonie/sodium_compat": "<1.24|>=2,<2.5",
                 "passbolt/passbolt_api": "<4.6.2",
+                "paymenter/paymenter": "<=1.5.4",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -3347,65 +3520,70 @@
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
                 "ph7software/ph7builder": "<=17.9.1",
-                "phanan/koel": "<5.1.4",
+                "phanan/koel": "<=9.7",
+                "pheditor/pheditor": "<2.0.8",
                 "phenx/php-svg-lib": "<0.5.2",
                 "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
                 "php-mod/curl": "<2.3.2",
-                "phpbb/phpbb": "<3.3.11",
+                "php-standard-library/h2": ">=6.1,<6.1.2|>=6.2,<6.2.1",
+                "php-standard-library/php-standard-library": ">=6.1,<6.1.2|>=6.2,<6.2.1",
+                "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<5.2.2",
-                "phpmyfaq/phpmyfaq": "<=4.1",
+                "phpmyfaq/phpmyfaq": "<4.1.4",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<1.30|>=2,<2.1.12|>=2.2,<2.4|>=3,<3.10|>=4,<5",
+                "phpoffice/phpspreadsheet": "<=1.30.5|>=2,<=2.1.17|>=2.2,<=2.4.6|>=3,<=3.10.6|>=4,<=5.8",
                 "phppgadmin/phppgadmin": "<=7.13",
-                "phpseclib/phpseclib": "<=2.0.51|>=3,<=3.0.49",
+                "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
-                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8",
+                "phpunit/phpunit": "<8.5.52|>=9,<9.6.33|>=10,<10.5.62|>=11,<11.5.50|>=12,<12.5.8|>=12.5.21,<12.5.22|>=13.1.5,<13.1.6",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "phraseanet/phraseanet": "==4.0.3",
                 "pi/pi": "<=2.5",
-                "pimcore/admin-ui-classic-bundle": "<=1.7.15|>=2.0.0.0-RC1-dev,<=2.2.2",
+                "pimcore/admin-ui-classic-bundle": "<1.7.18|>=2.0.0.0-RC1-dev,<=2.3.5",
                 "pimcore/customer-management-framework-bundle": "<4.2.1",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
                 "pimcore/demo": "<10.3",
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<=11.5.14.1|>=12,<12.3.3",
+                "pimcore/pimcore": "<=12.3.8|>=2026.1,<2026.1.3",
                 "pimcore/web2print-tools-bundle": "<=5.2.1|>=6.0.0.0-RC1-dev,<=6.1",
                 "piwik/piwik": "<1.11",
                 "pixelfed/pixelfed": "<0.12.5",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
-                "pocketmine/pocketmine-mp": "<5.32.1",
+                "pocketmine/pocketmine-mp": "<5.42.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
+                "pontedilana/php-weasyprint": "<=2.5.1",
+                "poweradmin/poweradmin": "<4.2.5|>=4.3,<4.3.4",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockreassurance": "<=5.1.3",
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.2.5|>=9.0.0.0-alpha1,<9.1",
+                "prestashop/prestashop": "<8.2.6|>=9,<9.1.1",
                 "prestashop/productcomments": "<5.0.2",
-                "prestashop/ps_checkout": "<4.4.1|>=5,<5.0.5",
+                "prestashop/ps_checkout": "<5.3",
                 "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
-                "prestashop/ps_facetedsearch": "<3.4.1",
+                "prestashop/ps_facetedsearch": "<4.0.4",
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4|>=1.7.7,<2.0.3",
-                "processwire/processwire": "<=3.0.246",
-                "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
-                "propel/propel1": ">=1,<=1.7.1",
+                "processwire/processwire": "<=3.0.255",
+                "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
+                "propel/propel1": ">=1,<1.7.2",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
-                "pterodactyl/panel": "<1.12.1",
+                "pterodactyl/panel": "<=1.12.4",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
@@ -3425,13 +3603,14 @@
                 "rap2hpoutre/laravel-log-viewer": "<0.13",
                 "react/http": ">=0.7,<1.9",
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
-                "redaxo/source": "<=5.20.1",
+                "redaxo/source": "<5.21",
                 "remdex/livehelperchat": "<4.29",
                 "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
                 "reportico-web/reportico": "<=8.1",
-                "rhukster/dom-sanitizer": "<1.0.7",
+                "rhukster/dom-sanitizer": "<1.0.10",
                 "rmccue/requests": ">=1.6,<1.8",
                 "roadiz/documents": "<2.3.42|>=2.4,<2.5.44|>=2.6,<2.6.28|>=2.7,<2.7.9",
+                "roadiz/openid": "<2.3.43|>=2.5,<2.5.45|>=2.6,<2.6.31|>=2.7,<2.7.18",
                 "robrichards/xmlseclibs": "<3.1.5",
                 "roots/soil": "<4.1",
                 "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11|>=1.7.0.0-beta,<1.7.0.0-RC5-dev",
@@ -3439,6 +3618,7 @@
                 "rudloff/rtmpdump-bin": "<=2.3.1",
                 "s-cart/core": "<=9.0.5",
                 "s-cart/s-cart": "<6.9",
+                "s9y/serendipity": "<2.6",
                 "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
                 "sabre/dav": ">=1.6,<1.7.11|>=1.8,<1.8.9",
                 "saloonphp/saloon": "<4",
@@ -3446,24 +3626,26 @@
                 "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
-                "setasign/fpdi": "<2.6.4",
+                "setasign/fpdi": "<2.6.7",
                 "sfroemken/url_redirect": "<=1.2.1",
                 "sheng/yiicms": "<1.2.1",
-                "shopware/core": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
-                "shopware/platform": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
+                "shopper/cart": "<2.8",
+                "shopper/framework": "<2.8",
+                "shopware/core": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
+                "shopware/platform": "<6.6.10.18-dev|>=6.7,<6.7.10.1-dev",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<=5.7.17|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
+                "shopware/shopware": "<=6.3.5.2|>=6.4.6,<6.6.10.10-dev|>=6.7,<6.7.6.1-dev",
                 "shopware/storefront": "<6.6.10.10-dev|>=6.7,<6.7.5.1-dev",
                 "shopxo/shopxo": "<=6.4",
-                "showdoc/showdoc": "<2.10.4",
+                "showdoc/showdoc": "<3.8.1",
                 "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
                 "silverstripe-australia/advancedreports": ">=1,<=2",
                 "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
-                "silverstripe/assets": ">=1,<1.11.1",
-                "silverstripe/cms": "<4.11.3",
+                "silverstripe/assets": "<2.4.5|>=3,<3.1.3",
+                "silverstripe/cms": "<6.2.1",
                 "silverstripe/comments": ">=1.3,<3.1.1",
-                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<5.3.23",
+                "silverstripe/forum": "<0.6.2|>=0.7,<0.7.4",
+                "silverstripe/framework": "<6.2.2",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/recipe-cms": ">=4.5,<4.5.3",
@@ -3473,13 +3655,15 @@
                 "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
                 "silverstripe/subsites": ">=2,<2.6.1",
                 "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
-                "silverstripe/userforms": "<3|>=5,<5.4.2",
+                "silverstripe/userforms": "<6.4.9|>=7,<7.0.7|>=7.1,<7.1.1",
+                "silverstripe/versioned": "<3.2.1",
                 "silverstripe/versioned-admin": ">=1,<1.11.1",
                 "simogeo/filemanager": "<=2.5",
                 "simple-updates/phpwhois": "<=1",
-                "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
-                "simplesamlphp/saml2-legacy": "<=4.16.15",
-                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/saml2": "<=4.20.2|>=5,<5.0.6|>=6,<6.2.1",
+                "simplesamlphp/saml2-legacy": "<=4.20.2",
+                "simplesamlphp/simplesamlphp": "<=2.4.6|>=2.5,<=2.5.1",
+                "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplesamlphp/simplesamlphp-module-openid": "<1",
                 "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
@@ -3491,19 +3675,23 @@
                 "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
                 "sjbr/static-info-tables": "<2.3.1",
                 "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
-                "slim/slim": "<2.6",
+                "slim/slim": "<2.6|>=4.4,<=4.15.1",
                 "slub/slub-events": "<3.0.3",
                 "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<8.3.7",
+                "snipe/snipe-it": "<=8.6.1",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
+                "solidinvoice/solidinvoice": "<=2.3.15",
                 "solspace/craft-freeform": "<4.1.29|>=5,<=5.14.6",
                 "soosyze/soosyze": "<=2",
                 "spatie/browsershot": "<5.0.5",
                 "spatie/image-optimizer": "<1.7.3",
+                "spatie/laravel-medialibrary": "<11.23",
+                "spatie/schema-org": ">=3.23.1,<3.23.2|>=4,<4.0.2",
                 "spencer14420/sp-php-email-handler": "<1",
                 "spipu/html2pdf": "<5.2.8",
                 "spiral/roadrunner": "<2025.1",
+                "spomky-labs/otphp": "<11.4.3",
                 "spoon/library": "<1.4.1",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
@@ -3512,14 +3700,14 @@
                 "starcitizentools/short-description": ">=4,<4.0.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
                 "starcitizenwiki/embedvideo": "<=4",
-                "statamic/cms": "<5.73.16|>=6,<6.7.2",
+                "statamic/cms": "<5.74|>=6,<6.20.3",
                 "stormpath/sdk": "<9.9.99",
-                "studio-42/elfinder": "<=2.1.64",
+                "studio-42/elfinder": "<=2.1.67",
                 "studiomitte/friendlycaptcha": "<0.1.4",
                 "subhh/libconnect": "<7.0.8|>=8,<8.1",
                 "sukohi/surpass": "<1",
                 "sulu/form-bundle": ">=2,<2.5.3",
-                "sulu/sulu": "<2.6.22|>=3,<3.0.5",
+                "sulu/sulu": "<=2.6.22|>=3,<=3.0.5",
                 "sumocoders/framework-user-bundle": "<1.4",
                 "superbig/craft-audit": "<3.0.2",
                 "svewap/a21glossary": "<=0.4.10",
@@ -3531,48 +3719,62 @@
                 "sylius/grid-bundle": "<1.10.1",
                 "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
-                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<=2.0.15|>=2.1,<=2.1.11|>=2.2,<=2.2.2",
+                "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<2.0.18|>=2.1,<2.1.15|>=2.2,<2.2.6",
+                "symbiote/silverstripe-advancedworkflow": "<6.4.5|>=7,<7.1.3|>=7.2,<7.2.1",
                 "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
                 "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
                 "symbiote/silverstripe-seed": "<6.0.3",
                 "symbiote/silverstripe-versionedfiles": "<=2.0.3",
                 "symfont/process": ">=0",
-                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/cache": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/dom-crawler": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
-                "symfony/http-client": ">=4.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
-                "symfony/http-foundation": "<5.4.50|>=6,<6.4.29|>=7,<7.3.7",
-                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+                "symfony/html-sanitizer": ">=6.1,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/http-client": ">=4.3,<5.4.53|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/http-foundation": "<5.4.50|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6|>=7.4,<7.4.12|>=8,<8.0.12",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/json-path": ">=7.3,<7.4.12|>=8,<8.0.12",
+                "symfony/lox24-notifier": ">=7.1,<7.4.12|>=8,<8.0.12",
+                "symfony/mailer": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailjet-mailer": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/mailomat-mailer": ">=7.2,<7.4.13|>=8,<8.0.13",
+                "symfony/mailtrap-mailer": ">=7.2,<7.4.12|>=8,<8.0.12",
                 "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
-                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/mime": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/monolog-bridge": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill": ">=1,<1.10|>=1.17.1,<1.38.1",
+                "symfony/polyfill-intl-idn": ">=1.17.1,<1.38.1",
                 "symfony/polyfill-php55": ">=1,<1.10",
                 "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
                 "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-                "symfony/routing": ">=2,<2.0.19",
-                "symfony/runtime": ">=5.3,<5.4.46|>=6,<6.4.14|>=7,<7.1.7",
+                "symfony/routing": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
+                "symfony/runtime": ">=5.3,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
                 "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
-                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
+                "symfony/security-http": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
-                "symfony/symfony": "<5.4.51|>=6,<6.4.33|>=7,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+                "symfony/symfony": "<5.4.53|>=6,<6.4.41|>=7,<7.4.13|>=8,<8.0.13",
                 "symfony/translation": ">=2,<2.0.17",
-                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8",
-                "symfony/ux-autocomplete": "<2.11.2",
-                "symfony/ux-live-component": "<2.25.1",
+                "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
+                "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+                "symfony/ux-autocomplete": "<2.36|>=3,<3.1",
+                "symfony/ux-icons": ">=2.17,<2.36.1|>=3,<3.2",
+                "symfony/ux-live-component": "<2.36|>=3,<3.1",
+                "symfony/ux-toolkit": ">=2.32,<2.36.1|>=3,<3.2",
                 "symfony/ux-twig-component": "<2.25.1",
                 "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
-                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4|>=7.2.9,<7.4.12|>=8,<8.0.12",
                 "symfony/webhook": ">=6.3,<6.3.8",
-                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7|>=2.2.0.0-beta1,<2.2.0.0-beta2",
+                "symfony/yaml": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
                 "symphonycms/symphony-2": "<2.6.4",
                 "t3/dce": "<0.11.5|>=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
@@ -3583,45 +3785,50 @@
                 "tecnickcom/tcpdf": "<6.8",
                 "terminal42/contao-tablelookupwizard": "<3.3.5",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1,<2.1.3",
+                "thelia/thelia": ">=2.0.0.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.1.1",
+                "thorsten/phpmyfaq": "<4.1.4",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
-                "tinymce/tinymce": "<7.2",
+                "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
                 "tinymighty/wiki-seo": "<1.2.2",
                 "titon/framework": "<9.9.99",
                 "tltneon/lgsl": "<7",
                 "tobiasbg/tablepress": "<=2.0.0.0-RC1",
+                "tomasnorre/crawler": "<11.0.13|>=12,<12.0.11",
                 "topthink/framework": "<6.0.17|>=6.1,<=8.0.4",
                 "topthink/think": "<=6.1.1",
                 "topthink/thinkphp": "<=3.2.3|>=6.1.3,<=8.0.4",
                 "torrentpier/torrentpier": "<=2.8.8",
-                "tpwd/ke_search": "<4.0.3|>=4.1,<4.6.6|>=5,<5.0.2",
+                "tpwd/ke_search": "<5.6.2|>=6,<6.6.1|>=7,<7.0.1",
                 "tribalsystems/zenario": "<=9.7.61188",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "ttskch/pagination-service-provider": "<1",
                 "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
-                "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
-                "typicms/core": "<16.1.7",
+                "twig/cssinliner-extra": "<3.26",
+                "twig/intl-extra": "<3.26",
+                "twig/markdown-extra": "<3.26",
+                "twig/twig": "<3.27",
+                "typicms/core": "<12.0.5|>=13,<13.0.9|>=14,<14.0.27|>=15,<15.0.29|>=16,<16.1.7",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
-                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
-                "typo3/cms-core": "<=8.7.56|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-felogin": ">=4.2,<4.2.3",
-                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1",
-                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-filelist": ">=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1|>=8,<8.7.23|>=9,<9.5.4",
+                "typo3/cms-form": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.5",
                 "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
-                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-indexed-search": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-install": "<4.1.14|>=4.2,<4.2.16|>=4.3,<4.3.9|>=4.4,<4.4.5|>=12.2,<12.4.8|==13.4.2",
                 "typo3/cms-lowlevel": ">=11,<=11.5.41",
                 "typo3/cms-recordlist": ">=11,<11.5.48",
-                "typo3/cms-recycler": ">=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
+                "typo3/cms-recycler": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-redirects": ">=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1",
                 "typo3/cms-rte-ckeditor": ">=9.5,<9.5.42|>=10,<10.4.39|>=11,<11.5.30",
                 "typo3/cms-scheduler": ">=11,<=11.5.41",
@@ -3629,7 +3836,7 @@
                 "typo3/cms-webhooks": ">=12,<=12.4.30|>=13,<=13.4.11",
                 "typo3/cms-workspaces": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
-                "typo3/html-sanitizer": ">=1,<=1.5.2|>=2,<=2.1.3",
+                "typo3/html-sanitizer": "<2.3.2",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
                 "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
                 "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
@@ -3645,7 +3852,7 @@
                 "uvdesk/core-framework": "<=1.1.1",
                 "vanilla/safecurl": "<0.9.2",
                 "verbb/comments": "<1.5.5",
-                "verbb/formie": "<=2.1.43",
+                "verbb/formie": "<3.1.28",
                 "verbb/image-resizer": "<2.0.9",
                 "verbb/knock-knock": "<1.2.8",
                 "verot/class.upload.php": "<=2.1.6",
@@ -3659,15 +3866,20 @@
                 "wallabag/wallabag": "<2.6.11",
                 "wanglelecc/laracms": "<=1.0.3",
                 "wapplersystems/a21glossary": "<=0.4.10",
-                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4",
-                "web-auth/webauthn-lib": ">=4.5,<4.9|>=5.2,<5.2.4",
-                "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9|>=5.2,<5.2.4|>=5.3,<5.3.1",
+                "web-auth/webauthn-lib": ">=4.5,<5.3.5",
+                "web-auth/webauthn-symfony-bundle": "<5.3.4",
                 "web-feet/coastercms": "==5.5",
+                "web-token/jwt-bundle": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
+                "web-token/jwt-experimental": "<4.1.7",
+                "web-token/jwt-framework": "<4.1.7",
+                "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
                 "web-tp3/wec_map": "<3.0.3",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
                 "webklex/laravel-imap": "<5.3",
                 "webklex/php-imap": "<5.3",
+                "webonyx/graphql-php": "<=15.32.2",
                 "webpa/webpa": "<3.1.2",
                 "webreinvent/vaahcms": "<=2.3.1",
                 "wikibase/wikibase": "<=1.39.3",
@@ -3679,25 +3891,27 @@
                 "winter/wn-system-module": "<1.2.4",
                 "wintercms/winter": "<=1.2.3",
                 "wireui/wireui": "<1.19.3|>=2,<2.1.3",
+                "wnx/laravel-backup-restore": "<=1.9.3",
                 "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
                 "wp-cli/wp-cli": ">=0.12,<2.5",
+                "wp-coding-standards/wpcs": ">=0.14.1,<3.4.1",
                 "wp-graphql/wp-graphql": "<=1.14.5",
                 "wp-premium/gravityforms": "<2.4.21",
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wpcloud/wp-stateless": "<3.2",
                 "wpglobus/wpglobus": "<=1.9.6",
                 "wpmetabox/meta-box": "<5.11.2",
-                "wwbn/avideo": "<=26",
+                "wwbn/avideo": "<=29",
                 "xataface/xataface": "<3",
                 "xpressengine/xpressengine": "<3.0.15",
                 "yab/quarx": "<2.4.5",
                 "yansongda/pay": "<=3.7.19",
-                "yeswiki/yeswiki": "<4.6",
+                "yeswiki/yeswiki": "<4.6.6",
                 "yetiforce/yetiforce-crm": "<6.5",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": "<1.1.31",
-                "yiisoft/yii2": "<2.0.52",
+                "yiisoft/yii2": "<2.0.55",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<=2.0.45",
@@ -3787,30 +4001,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-04T07:24:55+00:00"
+            "time": "2026-07-28T15:20:31+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
             },
             "bin": [
                 "bin/phpcbf",
@@ -3835,7 +4049,7 @@
                     "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
             "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
@@ -3866,7 +4080,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         }
     ],
     "aliases": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "devDependencies": {
         "husky": "~9.1.0",
-        "lint-staged": "~15.5.0",
-        "markdownlint-cli2": "~0.17.0",
-        "prettier": "~3.8.0"
+        "lint-staged": "~17.2.0",
+        "markdownlint-cli2": "~0.23.0",
+        "prettier": "~3.9.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -93,22 +93,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -120,19 +104,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -153,19 +124,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -201,69 +159,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -322,13 +225,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -340,50 +236,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/fast-glob": {
@@ -427,26 +279,13 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -466,34 +305,24 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.2",
-        "ignore": "^5.2.4",
-        "path-type": "^5.0.0",
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
         "slash": "^5.1.0",
-        "unicorn-magic": "^0.1.0"
+        "unicorn-magic": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
       }
     },
     "node_modules/husky": {
@@ -513,9 +342,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -569,19 +398,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -616,37 +432,40 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsonc-parser": {
@@ -656,10 +475,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/katex": {
-      "version": "0.16.44",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
-      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -673,148 +502,70 @@
         "katex": "cli.js"
       }
     },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/lint-staged": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
-      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
+      "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^13.1.0",
-        "debug": "^4.4.0",
-        "execa": "^8.0.1",
-        "lilconfig": "^3.1.3",
-        "listr2": "^8.2.5",
-        "micromatch": "^4.0.8",
-        "pidtree": "^0.6.0",
+        "picomatch": "^4.0.5",
         "string-argv": "^0.3.2",
-        "yaml": "^2.7.0"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/listr2": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^4.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -824,57 +575,60 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.37.4.tgz",
-      "integrity": "sha512-u00joA/syf3VhWh6/ybVFkib5Zpj2e5KB/cfCei8fkSRuums6nyisTWGqjTWIOFoFwuXoTBQQiqlB4qFKp8ncQ==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "markdown-it": "14.1.0",
-        "micromark": "4.0.1",
-        "micromark-core-commonmark": "2.0.2",
-        "micromark-extension-directive": "3.0.2",
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
         "micromark-extension-gfm-autolink-literal": "2.1.0",
         "micromark-extension-gfm-footnote": "2.1.0",
-        "micromark-extension-gfm-table": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
-        "micromark-util-types": "2.0.1"
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.17.2.tgz",
-      "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "14.0.2",
-        "js-yaml": "4.1.0",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
-        "markdownlint": "0.37.4",
-        "markdownlint-cli2-formatter-default": "0.0.5",
-        "micromatch": "4.0.8"
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.3.0",
+        "markdownlint": "0.41.1",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.7.0"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2-formatter-default": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz",
-      "integrity": "sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -885,16 +639,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -909,9 +656,9 @@
       }
     },
     "node_modules/micromark": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
-      "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
       "dev": true,
       "funding": [
         {
@@ -945,9 +692,9 @@
       }
     },
     "node_modules/micromark-core-commonmark": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
-      "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
       "dev": true,
       "funding": [
         {
@@ -980,9 +727,9 @@
       }
     },
     "node_modules/micromark-extension-directive": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1038,9 +785,9 @@
       }
     },
     "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
-      "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1428,9 +1175,9 @@
       "license": "MIT"
     },
     "node_modules/micromark-util-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
-      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
       "dev": true,
       "funding": [
         {
@@ -1458,30 +1205,17 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/ms": {
@@ -1490,51 +1224,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -1556,59 +1245,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1652,39 +1305,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1695,13 +1315,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -1727,42 +1340,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -1776,21 +1353,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">= 18"
       },
       "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/string-argv": {
@@ -1804,18 +1377,17 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1837,17 +1409,14 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=18"
       }
     },
     "node_modules/to-regex-range": {
@@ -1871,58 +1440,25 @@
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "husky": "~9.1.0",
-    "lint-staged": "~15.5.0",
-    "markdownlint-cli2": "~0.17.0",
-    "prettier": "~3.8.0"
+    "lint-staged": "~17.2.0",
+    "markdownlint-cli2": "~0.23.0",
+    "prettier": "~3.9.0"
   }
 }

--- a/src/Console/Command/Composition/AbstractTestCommand.php
+++ b/src/Console/Command/Composition/AbstractTestCommand.php
@@ -14,8 +14,9 @@ namespace DefaultValue\Dockerizer\Console\Command\Composition;
 
 use DefaultValue\Dockerizer\Shell\Shell;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
@@ -232,15 +233,60 @@ abstract class AbstractTestCommand extends \Symfony\Component\Console\Command\Co
     protected function logThrowable(\Throwable $e, string $debugData): void
     {
         $this->logger->emergency("FAILED! $debugData");
-        // Render exception and write it to the log file with backtrace
-        $output = new BufferedOutput();
-        $output->setVerbosity($output::VERBOSITY_VERY_VERBOSE);
+        // Log the throwable directly. `Application::renderThrowable()` writes nothing from a forked
+        // worker (the child process has no console output context), which is why every failure used
+        // to log a blank line and left the actual cause impossible to see.
+        $this->logger->emergency($this->formatThrowable($e));
+    }
 
-        if (!$this->getApplication()) {
-            throw new \LogicException('Application is not initialized');
+    /**
+     * Build a self-contained, log-friendly description of a throwable.
+     *
+     * A failed command is what fails almost every time here (`grunt`, `npm install`, `bin/magento …`),
+     * so those get a compact, readable entry — the command, why it failed and its own output — and
+     * NOT the framework backtrace, which is pure noise (Symfony Process/Console/Multithread internals).
+     * Only genuinely unexpected exceptions (a bug in our own code) get the full cause chain + backtrace.
+     *
+     * @param \Throwable $e
+     * @return string
+     */
+    private function formatThrowable(\Throwable $e): string
+    {
+        // A non-zero exit: the message already embeds the command, exit code and captured stdout/stderr.
+        if ($e instanceof ProcessFailedException) {
+            return $e->getMessage();
         }
 
-        $this->getApplication()->renderThrowable($e, $output);
-        $this->logger->emergency($output->fetch());
+        // A timeout message carries neither exit code nor output, so add them — partial output printed
+        // before the command hung is often the clue (e.g. it connected, then blocked on the DB).
+        if ($e instanceof ProcessTimedOutException) {
+            $process = $e->getProcess();
+            $stdout = trim($process->getOutput());
+            $stderr = trim($process->getErrorOutput());
+
+            return implode(PHP_EOL, [
+                $e->getMessage(),
+                'Exit code: ' . var_export($process->getExitCode(), true),
+                'STDOUT: ' . ($stdout !== '' ? PHP_EOL . $stdout : '(none)'),
+                'STDERR: ' . ($stderr !== '' ? PHP_EOL . $stderr : '(none)'),
+            ]);
+        }
+
+        // Unexpected exceptions: keep the full cause chain and backtrace — that is where we need them.
+        $parts = [];
+
+        for ($throwable = $e; $throwable !== null; $throwable = $throwable->getPrevious()) {
+            $parts[] = sprintf(
+                '%s: %s (%s:%d)',
+                $throwable::class,
+                $throwable->getMessage(),
+                $throwable->getFile(),
+                $throwable->getLine()
+            );
+        }
+
+        $parts[] = 'Trace:' . PHP_EOL . $e->getTraceAsString();
+
+        return implode(PHP_EOL, $parts);
     }
 }

--- a/src/Console/Command/Magento/TestModuleInstall.php
+++ b/src/Console/Command/Magento/TestModuleInstall.php
@@ -162,19 +162,19 @@ class TestModuleInstall extends \DefaultValue\Dockerizer\Console\Command\Abstrac
             $this->setupInstall->setupInstall($output, $composition);
             // Must run this here to ensure the module CAN be installed in case Magento is in the `production` mode
             // There are cases when this works fine in the `developer` mode, but fails in `production`
-            $phpService->mustRun('php bin/magento deploy:mode:set production', Shell::EXECUTION_TIMEOUT_LONG);
-            $phpService->mustRun('php bin/magento indexer:reindex', Shell::EXECUTION_TIMEOUT_LONG);
+            $phpService->mustRun('php bin/magento deploy:mode:set production', Shell::EXECUTION_TIMEOUT_MEDIUM);
+            $phpService->mustRun('php bin/magento indexer:reindex', Shell::EXECUTION_TIMEOUT_MEDIUM);
             $this->refreshModules($modules);
-            $phpService->mustRun('php bin/magento setup:upgrade', Shell::EXECUTION_TIMEOUT_LONG);
+            $phpService->mustRun('php bin/magento setup:upgrade', Shell::EXECUTION_TIMEOUT_MEDIUM);
         }
 
         $output->writeln('<info>Magento and modules installed successfully!</info>');
 
         # Step 4: Final switch to production mode
         $output->writeln('<info>Switching to the production mode...</info>');
-        $phpService->mustRun('php bin/magento deploy:mode:set production', Shell::EXECUTION_TIMEOUT_LONG);
+        $phpService->mustRun('php bin/magento deploy:mode:set production', Shell::EXECUTION_TIMEOUT_MEDIUM);
         $output->writeln('<info>Running reindex...</info>');
-        $phpService->mustRun('php bin/magento indexer:reindex', Shell::EXECUTION_TIMEOUT_LONG);
+        $phpService->mustRun('php bin/magento indexer:reindex', Shell::EXECUTION_TIMEOUT_MEDIUM);
 
         # Step 5: Commit changes
         $output->writeln('<info>Commit changes...</info>');

--- a/src/Console/Command/Magento/TestTemplates.php
+++ b/src/Console/Command/Magento/TestTemplates.php
@@ -90,6 +90,7 @@ class TestTemplates extends AbstractTestCommand
         '2.4.6-p10',
         '2.4.6-p11',
         '2.4.6-p14',
+        '2.4.6-p15',
         '2.4.7',
         '2.4.7-p3',
         '2.4.7-p4',
@@ -98,12 +99,14 @@ class TestTemplates extends AbstractTestCommand
         '2.4.7-p7',
         '2.4.7-p8',
         '2.4.7-p9',
+        '2.4.7-p10',
         '2.4.8',
         '2.4.8-p1',
         '2.4.8-p2',
         '2.4.8-p3',
         '2.4.8-p4',
-        '2.4.9-beta1'
+        '2.4.8-p5',
+        '2.4.9'
     ];
 
     /**

--- a/src/Console/Command/Magento/TestTemplates.php
+++ b/src/Console/Command/Magento/TestTemplates.php
@@ -512,17 +512,62 @@ class TestTemplates extends AbstractTestCommand
     {
         $this->logger->info('Test Grunt');
         $appContainers = $this->magento->initialize($dockerCompose);
-        $appContainers->runMagentoCommand('deploy:mode:set developer', true);
+        // Switching to developer mode wipes `generated/`. On the macOS Docker bind mount that delete
+        // intermittently loses a race - with the filesystem itself, or with an in-flight request such
+        // as a Varnish health probe regenerating code - and Magento aborts with
+        // `rmdir(...): Directory not empty`. Retry to ride out the transient state.
+        $this->runMagentoCommandWithRetry($appContainers, 'deploy:mode:set developer');
         /** @var Php $phpContainer */
         $phpContainer = $appContainers->getService(AppContainers::PHP_SERVICE);
 
         $phpContainer->mustRun('cp package.json.sample package.json');
         $phpContainer->mustRun('cp Gruntfile.js.sample Gruntfile.js');
 
-        $phpContainer->mustRun('npm install --save-dev', Shell::EXECUTION_TIMEOUT_LONG, false);
+        $this->logger->info('Test Grunt: run `npm install`');
+        $phpContainer->mustRun('npm install --save-dev', Shell::EXECUTION_TIMEOUT_MEDIUM, false);
+        $this->logger->info('Test Grunt: run grunt tasks');
         $phpContainer->mustRun('grunt clean:luma', Shell::EXECUTION_TIMEOUT_SHORT, false);
         $phpContainer->mustRun('grunt exec:luma', Shell::EXECUTION_TIMEOUT_SHORT, false);
         $phpContainer->mustRun('grunt less:luma', Shell::EXECUTION_TIMEOUT_SHORT, false);
+    }
+
+    /**
+     * Run a Magento command, retrying a few times when it fails. Intended for filesystem-heavy
+     * commands (e.g. `deploy:mode:set`, which wipes `generated/`) that fail intermittently on the
+     * macOS Docker bind mount with transient errors such as `rmdir(...): Directory not empty`.
+     * Timeouts are not retried - those are a resource problem, not a transient filesystem race.
+     *
+     * @param AppContainers $appContainers
+     * @param string $command
+     * @param int $attempts
+     * @param int $delaySeconds
+     * @return void
+     */
+    private function runMagentoCommandWithRetry(
+        AppContainers $appContainers,
+        string $command,
+        int $attempts = 3,
+        int $delaySeconds = 3
+    ): void {
+        for ($attempt = 1; $attempt < $attempts; $attempt++) {
+            try {
+                $appContainers->runMagentoCommand($command, true);
+
+                return;
+            } catch (ProcessFailedException) {
+                $this->logger->notice(sprintf(
+                    'Command "%s" failed (attempt %d/%d), retrying in %ds',
+                    $command,
+                    $attempt,
+                    $attempts,
+                    $delaySeconds
+                ));
+                sleep($delaySeconds);
+            }
+        }
+
+        // Final attempt: let any failure propagate so the test is reported as failed.
+        $appContainers->runMagentoCommand($command, true);
     }
 
     /**

--- a/src/Docker/Compose.php
+++ b/src/Docker/Compose.php
@@ -34,13 +34,11 @@ class Compose
 
     /**
      * @param \DefaultValue\Dockerizer\Shell\Shell $shell
-     * @param \DefaultValue\Dockerizer\Docker\Network $dockerNetwork
      * @param \DefaultValue\Dockerizer\Docker\Image $dockerImage,
      * @param string $cwd
      */
     public function __construct(
         private \DefaultValue\Dockerizer\Shell\Shell $shell,
-        private \DefaultValue\Dockerizer\Docker\Network $dockerNetwork,
         private \DefaultValue\Dockerizer\Docker\Image $dockerImage,
         private string $cwd = ''
     ) {
@@ -62,7 +60,7 @@ class Compose
             throw new \InvalidArgumentException('Working directory must not be empty!');
         }
 
-        return new self($this->shell, $this->dockerNetwork, $this->dockerImage, $cwd);
+        return new self($this->shell, $this->dockerImage, $cwd);
     }
 
     /**

--- a/src/Docker/ContainerizedService/Elasticsearch.php
+++ b/src/Docker/ContainerizedService/Elasticsearch.php
@@ -65,6 +65,33 @@ class Elasticsearch extends AbstractService
     }
 
     /**
+     * Major Elasticsearch version reported by the running container (e.g. 7 or 8). Used to pass the
+     * correct `--search-engine=elasticsearchN` flag to `setup:install`: a single Magento version can
+     * run either engine (2.4.7 ships both 7 and 8), and the two are not protocol-compatible, so the
+     * flag must follow the container, not the Magento version.
+     *
+     * @return int
+     * @throws \JsonException
+     */
+    public function getMajorVersion(): int
+    {
+        $meta = $this->getMeta();
+        $version = $meta['version'] ?? [];
+        $number = is_array($version) && isset($version['number']) && is_string($version['number'])
+            ? $version['number']
+            : '';
+
+        if ($number === '') {
+            throw new \RuntimeException(sprintf(
+                'Unable to determine the Elasticsearch version for container "%s"',
+                $this->getContainerName()
+            ));
+        }
+
+        return (int) explode('.', $number)[0];
+    }
+
+    /**
      * @param int $connectionRetries
      * @return void
      */

--- a/src/Platform/Magento/SetupInstall.php
+++ b/src/Platform/Magento/SetupInstall.php
@@ -102,10 +102,17 @@ class SetupInstall
                 $installationCommand .= ' --elasticsearch-host=' . AppContainers::ELASTICSEARCH_SERVICE;
             }
 
-            if (Comparator::greaterThanOrEqualTo($magentoVersion, '2.4.8')) {
-                $installationCommand .= ' --search-engine=elasticsearch8';
-            } elseif (Comparator::greaterThanOrEqualTo($magentoVersion, '2.4.4')) {
-                $installationCommand .= ' --search-engine=elasticsearch7';
+            // `--search-engine` exists since 2.4.4. Choose `elasticsearch7`/`elasticsearch8` from the
+            // running container, NOT the Magento version: a single version can ship either engine
+            // (e.g. 2.4.7-p10 runs Elasticsearch 8 while still being < 2.4.8), and they are not
+            // protocol-compatible - keying off the version installs Magento against the wrong engine.
+            // IMPORTANT! Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+            // Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+            // client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
+            if (Comparator::greaterThanOrEqualTo($magentoVersion, '2.4.4')) {
+                /** @var Elasticsearch $elasticsearchService */
+                $elasticsearchService = $appContainers->getService(AppContainers::ELASTICSEARCH_SERVICE);
+                $installationCommand .= ' --search-engine=elasticsearch' . $elasticsearchService->getMajorVersion();
             }
         }
 

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/generic_php_apache_app.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/generic_php_apache_app.yaml
@@ -21,7 +21,7 @@ app:
             - php_apache_development_image
             - mailhog
           parameters:
-            image_version: '8.5.4'
+            image_version: '8.5.8'
             web_root: 'pub/'
         php_8_4_apache:
           service: dv_php_apache_8_3
@@ -29,7 +29,7 @@ app:
             - php_apache_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_8_3
@@ -37,7 +37,7 @@ app:
             - php_apache_development_image
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -46,7 +46,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.0_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.0_nginx_varnish_apache.yaml
@@ -8,6 +8,7 @@ app:
   # Global parameters that are passed to every service
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.1-2.3.2_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.1-2.3.2_nginx_varnish_apache.yaml
@@ -8,6 +8,7 @@ app:
   # Global parameters that are passed to every service
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.3_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.3_nginx_varnish_apache.yaml
@@ -8,6 +8,7 @@ app:
   # Global parameters that are passed to every service
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.4_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.4_nginx_varnish_apache.yaml
@@ -8,6 +8,7 @@ app:
   # Global parameters that are passed to every service
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.5_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.5_nginx_varnish_apache.yaml
@@ -8,6 +8,7 @@ app:
   # Global parameters that are passed to every service
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.6_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.6_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.3.6 <2.3.7'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.7-p3_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.7-p3_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.3.7-p3 <2.4.0'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.7_2.3.7-p2_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.3.x/magento_2.3.7_2.3.7-p2_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.3.7 <2.3.7-p3'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.0/magento_2.4.0_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.0/magento_2.4.0_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.0 <2.4.1'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.1/magento_2.4.1_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.1/magento_2.4.1_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.1 <2.4.2'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.2/magento_2.4.2_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.2/magento_2.4.2_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.2 <2.4.3'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.3/magento_2.4.3-p2_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.3/magento_2.4.3-p2_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.3-p2 <2.4.4'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.3/magento_2.4.3_2.4.3-p1_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.3/magento_2.4.3_2.4.3-p1_nginx_varnish_apache.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.3 <2.4.3-p2'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p0_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p0_p2.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4 <2.4.4-p3'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p11.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p11.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p11 <2.4.4-p12'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p12.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p12.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p12 <2.4.4-p13'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p13.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p13.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p13 <2.4.5'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p3.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p3 <2.4.4-p4'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p4_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p4_p7.yaml
@@ -7,6 +7,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p4 <2.4.4-p8'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p8.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p8 <2.4.4-p9'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p9_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.4/magento_2.4.4_nginx_varnish_apache_p9_p10.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.4-p9 <2.4.4-p11'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p0_p1.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p0_p1.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5 <2.4.5-p2'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p10.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p10 <2.4.5-p11'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p11.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p11.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p11 <2.4.5-p12'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p12.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p12.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p12 <2.4.5-p13'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p13_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p13_p14.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p13 <2.4.6'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p2.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p2 <2.4.5-p3'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p3_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p3_p6.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p3 <2.4.5-p7'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p7.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p7 <2.4.5-p8'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.5/magento_2.4.5_nginx_varnish_apache_p8_p9.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.5-p8 <2.4.5-p10'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p0_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p0_p4.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p0_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p0_p4.yaml
@@ -52,6 +52,9 @@ app:
       # Does not work with 8.4! Installing Sample data and generating fixtures fail due to MSI issues.
       # https://github.com/magento/magento2/issues/36687#issuecomment-1475984941
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p11_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p11_p14.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p11_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p11_p14.yaml
@@ -45,6 +45,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p15.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p15.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.6-p11 - 2.4.6-p14 (Apache)
+  description: Magento 2.4.6-p15 (Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.6-p11 <2.4.6-p15'
-    magento/project-enterprise-edition: '>=2.4.6-p11 <2.4.6-p15'
-    magento/product-community-edition: '>=2.4.6-p11 <2.4.6-p15'
-    magento/product-enterprise-edition: '>=2.4.6-p11 <2.4.6-p15'
+    magento/project-community-edition: '>=2.4.6-p15 <2.4.7'
+    magento/project-enterprise-edition: '>=2.4.6-p15 <2.4.7'
+    magento/product-community-edition: '>=2.4.6-p15 <2.4.7'
+    magento/product-enterprise-edition: '>=2.4.6-p15 <2.4.7'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -34,31 +34,28 @@ app:
             image_version: '8.1.34'
             web_root: 'pub/'
       database:
-        mysql_8_0_persistent:
-          service: dv_mysql_8_0_to_8_4
-          dev_tools: phpmyadmin
-          parameters:
-            mysql_version: '8.0'
         mariadb_10_11_persistent:
           service: dv_mariadb_10_2_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '10.11'
       search_engine:
-        elasticsearch_7_17_20_persistent:
-          service: dv_elasticsearch
-          parameters:
-            elasticsearch_version: '7.17.20'
-        opensearch_2_19_0:
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
+        opensearch_2_19_6:
+          service: opensearch
+          dev_tools: opensearch_dashboards
+          parameters:
+            opensearch_version: '2.19.6'
+            opensearch_dashboards_version: '2.19.6'
 
     optional:
-      redis:
-        redis_7_2:
-          service: dv_redis
+      cache:
+        valkey_8_1:
+          service: dv_valkey
           parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p15.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p15.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p5.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p5.yaml
@@ -52,6 +52,9 @@ app:
       # Does not work with 8.4! Installing Sample data and generating fixtures fail due to MSI issues.
       # https://github.com/magento/magento2/issues/36687#issuecomment-1475984941
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p6.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p6.yaml
@@ -45,6 +45,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p7.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p7.yaml
@@ -45,6 +45,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p8.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p8.yaml
@@ -45,6 +45,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p9_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p9_p10.yaml
@@ -22,7 +22,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p9_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_apache_p9_p10.yaml
@@ -45,6 +45,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
@@ -71,6 +71,9 @@ app:
       # Does not work with 8.4! Installing Sample data and generating fixtures fail due to MSI issues.
       # https://github.com/magento/magento2/issues/36687#issuecomment-1475984941
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
@@ -41,7 +41,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p0.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6 <2.4.6-p1'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
@@ -2,12 +2,13 @@ app:
   description: Magento 2.4.6-p11 - 2.4.6-p14 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.6-p11 <2.4.7'
-    magento/project-enterprise-edition: '>=2.4.6-p11 <2.4.7'
-    magento/product-community-edition: '>=2.4.6-p11 <2.4.7'
-    magento/product-enterprise-edition: '>=2.4.6-p11 <2.4.7'
+    magento/project-community-edition: '>=2.4.6-p11 <2.4.6-p15'
+    magento/project-enterprise-edition: '>=2.4.6-p11 <2.4.6-p15'
+    magento/product-community-edition: '>=2.4.6-p11 <2.4.6-p15'
+    magento/product-enterprise-edition: '>=2.4.6-p11 <2.4.6-p15'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p11_p14.yaml
@@ -59,6 +59,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p15.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p15.yaml
@@ -1,14 +1,14 @@
 app:
-  description: Magento 2.4.6-p9 - 2.4.6-p10 (Nginx + Varnish + Apache)
+  description: Magento 2.4.6-p15 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.6-p9 <2.4.6-p11'
-    magento/project-enterprise-edition: '>=2.4.6-p9 <2.4.6-p11'
-    magento/product-community-edition: '>=2.4.6-p9 <2.4.6-p11'
-    magento/product-enterprise-edition: '>=2.4.6-p9 <2.4.6-p11'
+    magento/project-community-edition: '>=2.4.6-p15 <2.4.7'
+    magento/project-enterprise-edition: '>=2.4.6-p15 <2.4.7'
+    magento/product-community-edition: '>=2.4.6-p15 <2.4.7'
+    magento/product-enterprise-edition: '>=2.4.6-p15 <2.4.7'
   parameters:
     environment: 'prod'
-    nginx_version: latest
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -16,17 +16,17 @@ app:
   composition:
     required:
       nginx:
-        nginx_latest:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_6:
+        varnish_8_0:
           service: dv_varnish_magento
           parameters:
             backend_host: php
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.6-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
       apache:
         php_8_2_apache:
@@ -48,31 +48,28 @@ app:
             image_version: '8.1.34'
             web_root: 'pub/'
       database:
-        mysql_8_0_persistent:
-          service: dv_mysql_8_0_to_8_4
-          dev_tools: phpmyadmin
-          parameters:
-            mysql_version: '8.0'
-        mariadb_10_6_persistent:
+        mariadb_10_11_persistent:
           service: dv_mariadb_10_2_and_above
           dev_tools: phpmyadmin
           parameters:
-            mariadb_version: '10.6'
+            mariadb_version: '10.11'
       search_engine:
-        elasticsearch_7_17_20_persistent:
-          service: dv_elasticsearch
-          parameters:
-            elasticsearch_version: '7.17.20'
-        opensearch_2_19_0:
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
+        opensearch_2_19_6:
+          service: opensearch
+          dev_tools: opensearch_dashboards
+          parameters:
+            opensearch_version: '2.19.6'
+            opensearch_dashboards_version: '2.19.6'
 
     optional:
-      redis:
-        redis_7_2:
-          service: dv_redis
+      cache:
+        valkey_8_1:
+          service: dv_valkey
           parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p15.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p15.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
@@ -71,6 +71,9 @@ app:
       # Does not work with 8.4! Installing Sample data and generating fixtures fail due to MSI issues.
       # https://github.com/magento/magento2/issues/36687#issuecomment-1475984941
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
@@ -41,7 +41,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p1_p4.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6-p1 <2.4.6-p5'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
@@ -71,6 +71,9 @@ app:
       # Does not work with 8.4! Installing Sample data and generating fixtures fail due to MSI issues.
       # https://github.com/magento/magento2/issues/36687#issuecomment-1475984941
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6-p5 <2.4.6-p6'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p5.yaml
@@ -41,7 +41,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
@@ -59,6 +59,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6-p6 <2.4.6-p7'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p6.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6-p7 <2.4.6-p8'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
@@ -59,6 +59,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p7.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
@@ -59,6 +59,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.6-p8 <2.4.6-p9'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p8.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p9_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p9_p10.yaml
@@ -59,6 +59,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p9_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.6/magento_2.4.6_nginx_varnish_apache_p9_p10.yaml
@@ -36,7 +36,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
         php_8_1_apache:
           service: dv_php_apache_unsecure

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
@@ -47,7 +47,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
-        # Does not work with 8.11! Still installs package 7.17.2 due to the incorrect dependencies!
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p0_p3.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -33,7 +33,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
@@ -49,10 +49,13 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
-        elasticsearch_8_17_10_persistent:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
+        elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:
-            elasticsearch_version: '8.17.10'
+            elasticsearch_version: '7.17.20'
         opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.7-p8 - 2.4.7-p9 (Apache)
+  description: Magento 2.4.7-p10 (Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.7-p8 <2.4.7-p10'
-    magento/project-enterprise-edition: '>=2.4.7-p8 <2.4.7-p10'
-    magento/product-community-edition: '>=2.4.7-p8 <2.4.7-p10'
-    magento/product-enterprise-edition: '>=2.4.7-p8 <2.4.7-p10'
+    magento/project-community-edition: '>=2.4.7-p10 <2.4.8'
+    magento/project-enterprise-edition: '>=2.4.7-p10 <2.4.8'
+    magento/product-community-edition: '>=2.4.7-p10 <2.4.8'
+    magento/product-enterprise-edition: '>=2.4.7-p10 <2.4.8'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -38,44 +38,46 @@ app:
             image_version: '8.2.30'
             web_root: 'pub/'
       database:
-        mysql_8_0_persistent:
-          service: dv_mysql_8_0_to_8_4
+        mariadb_11_8_persistent:
+          service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
-            mysql_version: '8.0'
+            mariadb_version: '11.8'
         mariadb_10_11_persistent:
           service: dv_mariadb_10_2_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '10.11'
       search_engine:
-        elasticsearch_7_17_20_persistent:
+        elasticsearch_8_17_10_persistent:
           service: dv_elasticsearch
           parameters:
-            elasticsearch_version: '7.17.20'
-        opensearch_2_19_0:
+            elasticsearch_version: '8.17.10'
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
+        opensearch_2_19_6:
+          service: opensearch
+          dev_tools: opensearch_dashboards
+          parameters:
+            opensearch_version: '2.19.6'
+            opensearch_dashboards_version: '2.19.6'
 
     optional:
       cache:
-        valkey_8:
+        valkey_8_1:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
-          parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'
       message_queue:
         activemq_artemis_2:
           service: dv_activemq_artemis
           parameters:
             artemis_version: '2.53.0'
-        rabbitmq_4_1:
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p10.yaml
@@ -26,7 +26,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -35,7 +35,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mariadb_11_8_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
@@ -47,6 +47,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p4.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -33,7 +33,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
@@ -47,6 +47,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p5.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -33,7 +33,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
@@ -47,6 +47,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p6_p7.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -33,7 +33,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
@@ -49,6 +49,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_apache_p8_p9.yaml
@@ -26,7 +26,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache
@@ -35,7 +35,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.7 <2.4.7-p4'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
@@ -43,7 +43,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -52,7 +52,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p0_p3.yaml
@@ -66,7 +66,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
-        # Does not work with 8.11! Still installs package 7.17.2 due to the incorrect dependencies!
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
@@ -40,7 +40,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -49,7 +49,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mariadb_11_8_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
@@ -1,13 +1,14 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Apache)
+  description: Magento 2.4.7-p10 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.7-p10 <2.4.8'
+    magento/project-enterprise-edition: '>=2.4.7-p10 <2.4.8'
+    magento/product-community-edition: '>=2.4.7-p10 <2.4.8'
+    magento/product-enterprise-edition: '>=2.4.7-p10 <2.4.8'
   parameters:
     environment: 'prod'
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -20,65 +21,77 @@ app:
   composition:
     required:
       nginx:
-        nginx_latest:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_7:
+        varnish_8_0:
           service: dv_varnish_magento
           parameters:
             backend_host: php
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.7-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
       apache:
-        php_8_5_apache:
+        php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.5.4'
+            image_version: '8.3.30.1'
             web_root: 'pub/'
-        php_8_4_apache:
-          service: dv_php_apache_unsecure_8_3
+        php_8_2_apache:
+          service: dv_php_apache_unsecure
           dev_tools:
-            - php_apache_development_image_8_3
+            - php_apache_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            composer_version: 2
+            image_version: '8.2.30'
             web_root: 'pub/'
       database:
-        mariadb_11_4_persistent:
+        mariadb_11_8_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
-            mariadb_version: '11.4'
+            mariadb_version: '11.8'
+        mariadb_10_11_persistent:
+          service: dv_mariadb_10_2_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '10.11'
       search_engine:
-        opensearch_3_0_0:
+        elasticsearch_8_17_10_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.10'
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
+        opensearch_2_19_6:
+          service: opensearch
+          dev_tools: opensearch_dashboards
+          parameters:
+            opensearch_version: '2.19.6'
+            opensearch_dashboards_version: '2.19.6'
 
     optional:
       cache:
-        valkey_8:
+        valkey_8_1:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
-          parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'
       message_queue:
         activemq_artemis_2:
           service: dv_activemq_artemis
           parameters:
             artemis_version: '2.53.0'
-        rabbitmq_4_1:
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p10.yaml
@@ -63,10 +63,13 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
-        elasticsearch_8_17_10_persistent:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
+        elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:
-            elasticsearch_version: '8.17.10'
+            elasticsearch_version: '7.17.20'
         opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.7-p4 <2.4.7-p5'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
@@ -61,6 +61,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p4.yaml
@@ -38,7 +38,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -47,7 +47,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.7-p5 <2.4.7-p6'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
@@ -61,6 +61,9 @@ app:
           parameters:
             mariadb_version: '10.6'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p5.yaml
@@ -38,7 +38,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -47,7 +47,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
@@ -61,6 +61,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.7-p6 <2.4.7-p8'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p6_p7.yaml
@@ -38,7 +38,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -47,7 +47,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
@@ -40,7 +40,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
         php_8_2_apache:
           service: dv_php_apache_unsecure
@@ -49,7 +49,7 @@ app:
             - mailhog
           parameters:
             composer_version: 2
-            image_version: '8.2.30'
+            image_version: '8.2.32'
             web_root: 'pub/'
       database:
         mysql_8_0_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
@@ -63,6 +63,9 @@ app:
           parameters:
             mariadb_version: '10.11'
       search_engine:
+        # Elasticsearch 8 is listed in the system requirements, but this Magento version ships only the
+        # Magento_Elasticsearch7 module - root composer.json (`~7.17.0 || ~8.17.0`) resolves to the 7.17
+        # client, so the ES 8 engine has no working client here. Use Elasticsearch 7.17 or OpenSearch.
         elasticsearch_7_17_20_persistent:
           service: dv_elasticsearch
           parameters:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.7/magento_2.4.7_nginx_varnish_apache_p8_p9.yaml
@@ -2,12 +2,13 @@ app:
   description: Magento 2.4.7-p8 - 2.4.7-p9 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.7-p8 <2.4.8'
-    magento/project-enterprise-edition: '>=2.4.7-p8 <2.4.8'
-    magento/product-community-edition: '>=2.4.7-p8 <2.4.8'
-    magento/product-enterprise-edition: '>=2.4.7-p8 <2.4.8'
+    magento/project-community-edition: '>=2.4.7-p8 <2.4.7-p10'
+    magento/project-enterprise-edition: '>=2.4.7-p8 <2.4.7-p10'
+    magento/product-community-edition: '>=2.4.7-p8 <2.4.7-p10'
+    magento/product-enterprise-edition: '>=2.4.7-p8 <2.4.7-p10'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p0.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_8_3
@@ -32,7 +32,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p1_p2.yaml
@@ -24,7 +24,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_8_3
@@ -32,7 +32,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p3_p4.yaml
@@ -26,7 +26,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_8_3
@@ -34,7 +34,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p5.yaml
@@ -26,7 +26,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_8_3
@@ -34,7 +34,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_apache_p5.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.9-beta1 (Apache)
+  description: Magento 2.4.8-p5 (Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/project-enterprise-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-enterprise-edition: '>=2.4.8-p5 <2.4.9'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -20,14 +20,6 @@ app:
   composition:
     required:
       apache:
-        php_8_5_apache:
-          service: dv_php_apache_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
-          parameters:
-            image_version: '8.5.4'
-            web_root: 'pub/'
         php_8_4_apache:
           service: dv_php_apache_8_3
           dev_tools:
@@ -36,36 +28,54 @@ app:
           parameters:
             image_version: '8.4.19'
             web_root: 'pub/'
+        php_8_3_apache:
+          service: dv_php_apache_8_3
+          dev_tools:
+            - php_apache_development_image_8_3
+            - mailhog
+          parameters:
+            image_version: '8.3.30.1'
+            web_root: 'pub/'
       database:
+        mysql_8_4_persistent:
+          service: dv_mysql_8_0_to_8_4
+          dev_tools: phpmyadmin
+          parameters:
+            mysql_version: '8.4'
+        mariadb_11_8_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '11.8'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
-        opensearch_3_0_0:
+        elasticsearch_8_17_10_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.10'
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_8_1:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
-          parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'
       message_queue:
         activemq_artemis_2:
           service: dv_activemq_artemis
           parameters:
             artemis_version: '2.53.0'
-        rabbitmq_4_1:
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p0.yaml
@@ -38,7 +38,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
@@ -46,7 +46,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
@@ -38,7 +38,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
@@ -46,7 +46,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p1_p2.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
@@ -2,12 +2,13 @@ app:
   description: Magento 2.4.8-p3 - 2.4.8-p4 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8-p3 <2.4.9'
-    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.9'
-    magento/product-community-edition: '>=2.4.8-p3 <2.4.9'
-    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.9'
+    magento/project-community-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/product-community-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p3_p4.yaml
@@ -40,7 +40,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
@@ -48,7 +48,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p5.yaml
@@ -1,13 +1,14 @@
 app:
-  description: Magento 2.4.9-beta1 (Nginx + Varnish + Nginx + PHP-FPM)
+  description: Magento 2.4.8-p5 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/project-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-community-edition: '>=2.4.9-beta1 <2.4.9-p1'
-    magento/product-enterprise-edition: '>=2.4.9-beta1 <2.4.9-p1'
+    magento/project-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/project-enterprise-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-enterprise-edition: '>=2.4.8-p5 <2.4.9'
   parameters:
     environment: 'prod'
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -19,71 +20,76 @@ app:
     artemis_password: magento
   composition:
     required:
-      nginx_ssl_proxy:
-        nginx_latest:
+      nginx:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_7:
-          service: dv_varnish_magento_v7
+        varnish_8_0:
+          service: dv_varnish_magento
           parameters:
-            backend_host: nginx-magento
+            backend_host: php
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.7-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
-      nginx_web:
-        nginx_magento_for_fpm:
-          service: dv_nginx_magento_for_fpm
-          parameters:
-            upstream_fpm: 'php:9000'
-      php_fpm:
-        php_8_5_fpm:
-          service: dv_php_fpm_8_3_to_8_5
+      apache:
+        php_8_4_apache:
+          service: dv_php_apache_unsecure_8_3
           dev_tools:
-            - php_fpm_development_image
-            - mailhog
-          parameters:
-            image_version: '8.5.4'
-            web_root: 'pub/'
-        php_8_4_fpm:
-          service: dv_php_fpm_8_3_to_8_5
-          dev_tools:
-            - php_fpm_development_image
+            - php_apache_development_image_8_3
             - mailhog
           parameters:
             image_version: '8.4.19'
             web_root: 'pub/'
+        php_8_3_apache:
+          service: dv_php_apache_unsecure_8_3
+          dev_tools:
+            - php_apache_development_image_8_3
+            - mailhog
+          parameters:
+            image_version: '8.3.30.1'
+            web_root: 'pub/'
       database:
+        mysql_8_4_persistent:
+          service: dv_mysql_8_0_to_8_4
+          dev_tools: phpmyadmin
+          parameters:
+            mysql_version: '8.4'
+        mariadb_11_8_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '11.8'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
-        opensearch_3_0_0:
+        elasticsearch_8_17_10_persistent:
+          service: dv_elasticsearch
+          parameters:
+            elasticsearch_version: '8.17.10'
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_8_1:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
-          parameters:
-            redis_version: '7.2'
+            valkey_version: '8.1'
       message_queue:
         activemq_artemis_2:
           service: dv_activemq_artemis
           parameters:
             artemis_version: '2.53.0'
-        rabbitmq_4_1:
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_apache_p5.yaml
@@ -40,7 +40,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_apache:
           service: dv_php_apache_unsecure_8_3
@@ -48,7 +48,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
@@ -43,7 +43,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_fpm:
           service: dv_php_fpm_8_3_to_8_5
@@ -51,7 +51,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p0.yaml
@@ -8,6 +8,7 @@ app:
     magento/product-enterprise-edition: '>=2.4.8 <2.4.8-p1'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p1_p2.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p1_p2.yaml
@@ -43,7 +43,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_fpm:
           service: dv_php_fpm_8_3_to_8_5
@@ -51,7 +51,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
@@ -45,7 +45,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_fpm:
           service: dv_php_fpm_8_3_to_8_5
@@ -53,7 +53,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p3_p4.yaml
@@ -2,12 +2,13 @@ app:
   description: Magento 2.4.8-p3 - 2.4.8-p4 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8-p3 <2.4.9'
-    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.9'
-    magento/product-community-edition: '>=2.4.8-p3 <2.4.9'
-    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.9'
+    magento/project-community-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/product-community-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p5.yaml
@@ -45,7 +45,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
+            image_version: '8.4.23'
             web_root: 'pub/'
         php_8_3_fpm:
           service: dv_php_fpm_8_3_to_8_5
@@ -53,7 +53,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.3.32'
             web_root: 'pub/'
       database:
         mysql_8_4_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p5.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.8/magento_2.4.8_nginx_varnish_nginx_fpm_p5.yaml
@@ -1,14 +1,14 @@
 app:
-  description: Magento 2.4.8-p1 - 2.4.8-p2 (Nginx + Varnish + Nginx + PHP-FPM)
+  description: Magento 2.4.8-p5 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/project-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/product-community-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/product-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
+    magento/project-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/project-enterprise-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-community-edition: '>=2.4.8-p5 <2.4.9'
+    magento/product-enterprise-edition: '>=2.4.8-p5 <2.4.9'
   parameters:
     environment: 'prod'
-    nginx_version: latest
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -16,20 +16,22 @@ app:
     rabbitmq_username: magento
     rabbitmq_password: magento
     rabbitmq_vhost: /
+    artemis_username: magento
+    artemis_password: magento
   composition:
     required:
       nginx_ssl_proxy:
-        nginx_latest:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_7:
+        varnish_8_0:
           service: dv_varnish_magento_v7
           parameters:
             backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.7-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
       nginx_web:
         nginx_magento_for_fpm:
@@ -59,35 +61,40 @@ app:
           dev_tools: phpmyadmin
           parameters:
             mysql_version: '8.4'
+        mariadb_11_8_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '11.8'
         mariadb_11_4_persistent:
           service: dv_mariadb_11_and_above
           dev_tools: phpmyadmin
           parameters:
             mariadb_version: '11.4'
       search_engine:
-        elasticsearch_8_17_0_persistent:
+        elasticsearch_8_17_10_persistent:
           service: dv_elasticsearch
           parameters:
-            elasticsearch_version: '8.17.0'
-        opensearch_2_19_0:
+            elasticsearch_version: '8.17.10'
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_8_1:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
+            valkey_version: '8.1'
+      message_queue:
+        activemq_artemis_2:
+          service: dv_activemq_artemis
           parameters:
-            redis_version: '7.2'
-      rabbitmq:
-        rabbitmq_4_1:
+            artemis_version: '2.53.0'
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_p0.yaml
@@ -26,7 +26,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.5.4'
+            image_version: '8.5.8'
             web_root: 'pub/'
       database:
         mariadb_12_3_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_apache_p0.yaml
@@ -1,11 +1,11 @@
 app:
-  description: Magento 2.4.8-p3 - 2.4.8-p4 (Apache)
+  description: Magento 2.4.9 (Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8-p3 <2.4.8-p5'
-    magento/project-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
-    magento/product-community-edition: '>=2.4.8-p3 <2.4.8-p5'
-    magento/product-enterprise-edition: '>=2.4.8-p3 <2.4.8-p5'
+    magento/project-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/project-enterprise-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-enterprise-edition: '>=2.4.9 <2.4.9-p1'
   parameters:
     environment: 'prod'
     mysql_root_random_password: ''
@@ -20,61 +20,45 @@ app:
   composition:
     required:
       apache:
-        php_8_4_apache:
+        php_8_5_apache:
           service: dv_php_apache_8_3
           dev_tools:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
-            web_root: 'pub/'
-        php_8_3_apache:
-          service: dv_php_apache_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
-          parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.5.4'
             web_root: 'pub/'
       database:
+        mariadb_12_3_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '12.3'
         mysql_8_4_persistent:
           service: dv_mysql_8_0_to_8_4
           dev_tools: phpmyadmin
           parameters:
             mysql_version: '8.4'
-        mariadb_11_4_persistent:
-          service: dv_mariadb_11_and_above
-          dev_tools: phpmyadmin
-          parameters:
-            mariadb_version: '11.4'
       search_engine:
-        elasticsearch_8_17_0_persistent:
-          service: dv_elasticsearch
-          parameters:
-            elasticsearch_version: '8.17.0'
-        opensearch_3_0_0:
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '3.0.0'
-            opensearch_dashboards_version: '3.0.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_9:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
-          parameters:
-            redis_version: '7.2'
+            valkey_version: '9'
       message_queue:
         activemq_artemis_2:
           service: dv_activemq_artemis
           parameters:
             artemis_version: '2.53.0'
-        rabbitmq_4_1:
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_apache_p0.yaml
@@ -1,14 +1,14 @@
 app:
-  description: Magento 2.4.8 (Nginx + Varnish + Apache)
+  description: Magento 2.4.9 (Nginx + Varnish + Apache)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8 <2.4.8-p1'
-    magento/project-enterprise-edition: '>=2.4.8 <2.4.8-p1'
-    magento/product-community-edition: '>=2.4.8 <2.4.8-p1'
-    magento/product-enterprise-edition: '>=2.4.8 <2.4.8-p1'
+    magento/project-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/project-enterprise-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-enterprise-edition: '>=2.4.9 <2.4.9-p1'
   parameters:
     environment: 'prod'
-    nginx_version: latest
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -16,73 +16,63 @@ app:
     rabbitmq_username: magento
     rabbitmq_password: magento
     rabbitmq_vhost: /
+    artemis_username: magento
+    artemis_password: magento
   composition:
     required:
       nginx:
-        nginx_latest:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_6:
+        varnish_8_0:
           service: dv_varnish_magento
           parameters:
             backend_host: php
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.6-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
       apache:
-        php_8_4_apache:
+        php_8_5_apache:
           service: dv_php_apache_unsecure_8_3
           dev_tools:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.4.19'
-            web_root: 'pub/'
-        php_8_3_apache:
-          service: dv_php_apache_unsecure_8_3
-          dev_tools:
-            - php_apache_development_image_8_3
-            - mailhog
-          parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.5.4'
             web_root: 'pub/'
       database:
+        mariadb_12_3_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '12.3'
         mysql_8_4_persistent:
           service: dv_mysql_8_0_to_8_4
           dev_tools: phpmyadmin
           parameters:
             mysql_version: '8.4'
-        mariadb_11_4_persistent:
-          service: dv_mariadb_11_and_above
-          dev_tools: phpmyadmin
-          parameters:
-            mariadb_version: '11.4'
       search_engine:
-        elasticsearch_8_17_0_persistent:
-          service: dv_elasticsearch
-          parameters:
-            elasticsearch_version: '8.17.0'
-        opensearch_2_19_0:
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_9:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
+            valkey_version: '9'
+      message_queue:
+        activemq_artemis_2:
+          service: dv_activemq_artemis
           parameters:
-            redis_version: '7.2'
-      rabbitmq:
-        rabbitmq_4_1:
+            artemis_version: '2.53.0'
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_apache_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_apache_p0.yaml
@@ -40,7 +40,7 @@ app:
             - php_apache_development_image_8_3
             - mailhog
           parameters:
-            image_version: '8.5.4'
+            image_version: '8.5.8'
             web_root: 'pub/'
       database:
         mariadb_12_3_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_p0.yaml
@@ -45,7 +45,7 @@ app:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.5.4'
+            image_version: '8.5.8'
             web_root: 'pub/'
       database:
         mariadb_12_3_persistent:

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_p0.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/magento/2.4.9/magento_2.4.9_nginx_varnish_nginx_fpm_p0.yaml
@@ -1,14 +1,14 @@
 app:
-  description: Magento 2.4.8-p1 - 2.4.8-p2 (Nginx + Varnish + Nginx + PHP-FPM)
+  description: Magento 2.4.9 (Nginx + Varnish + Nginx + PHP-FPM)
   # System requirements: https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
   supported_packages:
-    magento/project-community-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/project-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/product-community-edition: '>=2.4.8-p1 <2.4.8-p3'
-    magento/product-enterprise-edition: '>=2.4.8-p1 <2.4.8-p3'
+    magento/project-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/project-enterprise-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-community-edition: '>=2.4.9 <2.4.9-p1'
+    magento/product-enterprise-edition: '>=2.4.9 <2.4.9-p1'
   parameters:
     environment: 'prod'
-    nginx_version: latest
+    nginx_version: '1.30'
     mysql_root_random_password: ''
     mysql_database: magento_db
     mysql_user: magento_user
@@ -16,20 +16,22 @@ app:
     rabbitmq_username: magento
     rabbitmq_password: magento
     rabbitmq_vhost: /
+    artemis_username: magento
+    artemis_password: magento
   composition:
     required:
       nginx_ssl_proxy:
-        nginx_latest:
+        nginx:
           service: dv_nginx_proxy_for_varnish
       varnish:
-        varnish_7_7:
+        varnish_8_0:
           service: dv_varnish_magento_v7
           parameters:
             backend_host: nginx-magento
             grace_period: 300
             ssl_offloaded_header: 'X-Forwarded-Proto'
             health_check: '/health_check.php'
-            varnish_version: 7.7-alpine
+            varnish_version: 8.0-alpine
             varnish_port: 80
       nginx_web:
         nginx_magento_for_fpm:
@@ -37,57 +39,45 @@ app:
           parameters:
             upstream_fpm: 'php:9000'
       php_fpm:
-        php_8_4_fpm:
+        php_8_5_fpm:
           service: dv_php_fpm_8_3_to_8_5
           dev_tools:
             - php_fpm_development_image
             - mailhog
           parameters:
-            image_version: '8.4.19'
-            web_root: 'pub/'
-        php_8_3_fpm:
-          service: dv_php_fpm_8_3_to_8_5
-          dev_tools:
-            - php_fpm_development_image
-            - mailhog
-          parameters:
-            image_version: '8.3.30.1'
+            image_version: '8.5.4'
             web_root: 'pub/'
       database:
+        mariadb_12_3_persistent:
+          service: dv_mariadb_11_and_above
+          dev_tools: phpmyadmin
+          parameters:
+            mariadb_version: '12.3'
         mysql_8_4_persistent:
           service: dv_mysql_8_0_to_8_4
           dev_tools: phpmyadmin
           parameters:
             mysql_version: '8.4'
-        mariadb_11_4_persistent:
-          service: dv_mariadb_11_and_above
-          dev_tools: phpmyadmin
-          parameters:
-            mariadb_version: '11.4'
       search_engine:
-        elasticsearch_8_17_0_persistent:
-          service: dv_elasticsearch
-          parameters:
-            elasticsearch_version: '8.17.0'
-        opensearch_2_19_0:
+        opensearch_3_7_0:
           service: opensearch
           dev_tools: opensearch_dashboards
           parameters:
-            opensearch_version: '2.19.0'
-            opensearch_dashboards_version: '2.19.0'
+            opensearch_version: '3.7.0'
+            opensearch_dashboards_version: '3.7.0'
 
     optional:
       cache:
-        valkey_8:
+        valkey_9:
           service: dv_valkey
           parameters:
-            valkey_version: '8'
-        redis_7_2:
-          service: dv_redis
+            valkey_version: '9'
+      message_queue:
+        activemq_artemis_2:
+          service: dv_activemq_artemis
           parameters:
-            redis_version: '7.2'
-      rabbitmq:
-        rabbitmq_4_1:
+            artemis_version: '2.53.0'
+        rabbitmq_4_2:
           service: dv_rabbitmq
           parameters:
-            rabbitmq_version: '4.1'
+            rabbitmq_version: '4.2'

--- a/templates/vendor/defaultvalue/dockerizer-templates/composition/shopware/shopware_6.4.x_nginx_varnish_apache.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/composition/shopware/shopware_6.4.x_nginx_varnish_apache.yaml
@@ -4,6 +4,7 @@ app:
     shopware/core: '~6.4.0'
   parameters:
     environment: 'prod'
+    nginx_version: latest
     mysql_root_random_password: ''
     mysql_database: shopware_db
     mysql_user: shopware_user

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_magento_for_fpm.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_magento_for_fpm.yaml
@@ -2,7 +2,7 @@
 # Reached only from the `varnish-cache` container over the Docker network.
 services:
   nginx-magento:
-    image: nginx:latest
+    image: nginx:{{nginx_version}}
     restart: always
     volumes:
       - .:/var/www/html

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_proxy_for_varnish.yaml
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/nginx/dv_nginx_proxy_for_varnish.yaml
@@ -10,7 +10,7 @@ services:
     # Must be enclosed in double quotes, otherwise YAML is invalid
     # Container name is used as a directory name to dump composition files
     container_name: '{{domains|first}}-{{environment}}'
-    image: nginx:latest
+    image: nginx:{{nginx_version}}
     restart: always
     networks:
       default:

--- a/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/varnish/varnish_magento_v7.vcl
+++ b/templates/vendor/defaultvalue/dockerizer-templates/service/varnish/varnish/varnish_magento_v7.vcl
@@ -88,8 +88,8 @@ sub vcl_recv {
     std.collect(req.http.Cookie);
 
     # Remove all marketing get parameters to minimize the cache objects
-    if (req.url ~ "(\?|&)(gad_source|gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
-        set req.url = regsuball(req.url, "(gad_source|gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
+    if (req.url ~ "(\?|&)(gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+|gad_[a-z]+)=") {
+        set req.url = regsuball(req.url, "(gbraid|wbraid|_gl|dclid|gclsrc|srsltid|msclkid|gclid|cx|_kx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+|gad_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
         set req.url = regsub(req.url, "[?|&]+$", "");
     }
 


### PR DESCRIPTION
Magento 2.4.9 GA and new patch templates (2.4.6-p15, 2.4.7-p10, 2.4.8-p5), Varnish 8, per-release `nginx_version` for the PHP-FPM stack, PHP image bumps, dependency updates, and test-harness fixes.

Breaking: the SSL-termination proxy is now `ssl_termination_proxy` > `nginx_proxy` in every composition — saved `--required-services` values naming an old code must be updated.

Full details in `Changelog.md`.